### PR TITLE
Feature/hot water water heater platform

### DIFF
--- a/custom_components/tado_hijack/__init__.py
+++ b/custom_components/tado_hijack/__init__.py
@@ -45,6 +45,7 @@ PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.SELECT,
     Platform.CLIMATE,
+    Platform.WATER_HEATER
 ]
 
 
@@ -137,5 +138,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: TadoConfigEntry) -> boo
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         await async_unload_services(hass)
+        await entry.runtime_data.api_call_counter.async_unload()
 
     return cast(bool, unload_ok)

--- a/custom_components/tado_hijack/__init__.py
+++ b/custom_components/tado_hijack/__init__.py
@@ -138,6 +138,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: TadoConfigEntry) -> boo
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         await async_unload_services(hass)
-        await entry.runtime_data.api_call_counter.async_unload()
 
     return cast(bool, unload_ok)

--- a/custom_components/tado_hijack/binary_sensor.py
+++ b/custom_components/tado_hijack/binary_sensor.py
@@ -26,12 +26,18 @@ async def async_setup_entry(
     """Set up Tado binary sensors."""
     coordinator: TadoDataUpdateCoordinator = entry.runtime_data
     entities: list[BinarySensorEntity] = []
+    seen_devices: set[str] = set()
 
     for zone in coordinator.zones_meta.values():
         if zone.type not in ("HEATING", "AIR_CONDITIONING", "HOT_WATER"):
             continue
 
         for device in zone.devices:
+            # Skip devices we've already processed (can appear in multiple zones)
+            if device.serial_no in seen_devices:
+                continue
+            seen_devices.add(device.serial_no)
+
             entities.extend(
                 (
                     TadoBatterySensor(coordinator, device, zone.id),

--- a/custom_components/tado_hijack/binary_sensor.py
+++ b/custom_components/tado_hijack/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import TadoDeviceEntity, TadoHomeEntity
+from .entity import TadoDeviceEntity, TadoHomeEntity, TadoHotWaterZoneEntity
 
 if TYPE_CHECKING:
     from . import TadoConfigEntry
@@ -49,6 +49,18 @@ async def async_setup_entry(
         TadoBridgeConnectionSensor(coordinator, bridge)
         for bridge in coordinator.bridges
     )
+
+    # Hot Water Zone Sensors
+    for zone in coordinator.zones_meta.values():
+        if zone.type == "HOT_WATER":
+            entities.extend(
+                (
+                    TadoHotWaterOverlaySensor(coordinator, zone.id, zone.name),
+                    TadoHotWaterPowerSensor(coordinator, zone.id, zone.name),
+                    TadoHotWaterConnectivitySensor(coordinator, zone.id, zone.name),
+                )
+            )
+
     async_add_entities(entities)
 
 
@@ -133,3 +145,72 @@ class TadoBridgeConnectionSensor(TadoHomeEntity, BinarySensorEntity):
             ),
             False,
         )
+
+
+class TadoHotWaterOverlaySensor(TadoHotWaterZoneEntity, BinarySensorEntity):
+    """Binary sensor showing if hot water has a manual overlay active."""
+
+    # No device class - shows On/Off states (not Plugged in/Unplugged)
+
+    def __init__(self, coordinator: Any, zone_id: int, zone_name: str) -> None:
+        """Initialize hot water overlay sensor."""
+        super().__init__(coordinator, "overlay", zone_id, zone_name)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_hw_overlay_{zone_id}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if manual overlay is active."""
+        state = self.coordinator.data.zone_states.get(str(self._zone_id))
+        if state is None:
+            return False
+        return bool(getattr(state, "overlay_active", False))
+
+
+class TadoHotWaterPowerSensor(TadoHotWaterZoneEntity, BinarySensorEntity):
+    """Binary sensor showing if hot water power is ON."""
+
+    _attr_device_class = BinarySensorDeviceClass.POWER
+
+    def __init__(self, coordinator: Any, zone_id: int, zone_name: str) -> None:
+        """Initialize hot water power sensor."""
+        super().__init__(coordinator, "power", zone_id, zone_name)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_hw_power_{zone_id}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if hot water power is ON."""
+        state = self.coordinator.data.zone_states.get(str(self._zone_id))
+        if state is None:
+            return False
+        setting = getattr(state, "setting", None)
+        if setting:
+            return getattr(setting, "power", "OFF") == "ON"
+        return False
+
+
+class TadoHotWaterConnectivitySensor(TadoHotWaterZoneEntity, BinarySensorEntity):
+    """Binary sensor showing hot water zone connectivity (Connected/Disconnected)."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, coordinator: Any, zone_id: int, zone_name: str) -> None:
+        """Initialize hot water connectivity sensor."""
+        super().__init__(coordinator, "connectivity", zone_id, zone_name)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_hw_conn_{zone_id}"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if hot water zone is connected.
+
+        Checks if any device in the zone is connected.
+        """
+        zone = self.coordinator.zones_meta.get(self._zone_id)
+        if zone is None:
+            return False
+
+        for device in zone.devices:
+            device_meta = self.coordinator.devices_meta.get(device.serial_no)
+            if device_meta and device_meta.connection_state:
+                if device_meta.connection_state.value:
+                    return True
+        return False

--- a/custom_components/tado_hijack/climate.py
+++ b/custom_components/tado_hijack/climate.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .climate_entity import TadoAirConditioning, TadoWaterHeater
-from .const import ZONE_TYPE_AIR_CONDITIONING, ZONE_TYPE_HOT_WATER
+from .climate_entity import TadoAirConditioning
+from .const import ZONE_TYPE_AIR_CONDITIONING
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -23,18 +23,11 @@ async def async_setup_entry(
     """Set up Tado climate entities."""
     coordinator: TadoDataUpdateCoordinator = entry.runtime_data
 
-    entities: list[TadoWaterHeater | TadoAirConditioning] = []
-
-    entities.extend(
-        TadoWaterHeater(coordinator, zone.id, zone.name)
-        for zone in coordinator.zones_meta.values()
-        if zone.type == ZONE_TYPE_HOT_WATER
-    )
-
-    entities.extend(
+    # Hot water uses WaterHeaterEntity (water_heater.py), not ClimateEntity
+    entities: list[TadoAirConditioning] = [
         TadoAirConditioning(coordinator, zone.id, zone.name)
         for zone in coordinator.zones_meta.values()
         if zone.type == ZONE_TYPE_AIR_CONDITIONING
-    )
+    ]
 
     async_add_entities(entities)

--- a/custom_components/tado_hijack/const.py
+++ b/custom_components/tado_hijack/const.py
@@ -102,6 +102,7 @@ SERVICE_TURN_OFF_ALL_ZONES = "turn_off_all_zones"
 SERVICE_BOOST_ALL_ZONES = "boost_all_zones"
 SERVICE_SET_TIMER = "set_timer"
 SERVICE_SET_TIMER_ALL = "set_timer_all_zones"
+SERVICE_SET_WATER_HEATER_TIMER = "set_water_heater_timer"
 
 # Device Capabilities
 CAPABILITY_INSIDE_TEMP: Final = "INSIDE_TEMPERATURE_MEASUREMENT"

--- a/custom_components/tado_hijack/coordinator.py
+++ b/custom_components/tado_hijack/coordinator.py
@@ -272,7 +272,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[TadoData]):
                 return True
         return False
 
-    def _get_active_zones(
+    def get_active_zones(
         self,
         include_heating: bool = True,
         include_ac: bool = False,
@@ -1094,7 +1094,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[TadoData]):
         _LOGGER.debug("Resume all schedules triggered")
 
         # Only resume HEATING zones, not HOT_WATER or AC
-        active_zones = self._get_active_zones(include_heating=True)
+        active_zones = self.get_active_zones(include_heating=True)
 
         if not active_zones:
             _LOGGER.warning("No active heating zones to resume")
@@ -1143,7 +1143,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[TadoData]):
             action_name: Human-readable action name for logging
 
         """
-        zone_ids = self._get_active_zones(include_heating=True)
+        zone_ids = self.get_active_zones(include_heating=True)
 
         if not zone_ids:
             _LOGGER.warning("No active heating zones to %s", action_name)

--- a/custom_components/tado_hijack/entity.py
+++ b/custom_components/tado_hijack/entity.py
@@ -134,6 +134,36 @@ class TadoZoneEntity(TadoEntity):
         )
 
 
+class TadoHotWaterZoneEntity(TadoEntity):
+    """Entity belonging to a specific Tado Hot Water Zone device."""
+
+    def __init__(
+        self,
+        coordinator: TadoDataUpdateCoordinator,
+        translation_key: str,
+        zone_id: int,
+        zone_name: str,
+    ) -> None:
+        """Initialize Tado hot water zone entity."""
+        super().__init__(coordinator, translation_key)
+        self._zone_id = zone_id
+        self._zone_name = zone_name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the hot water zone."""
+        if self.coordinator.config_entry is None:
+            raise RuntimeError("Config entry not available")
+        # Use zone name directly - Tado typically names it "Hot Water" already
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"zone_{self._zone_id}")},
+            name=self._zone_name,
+            manufacturer="Tado",
+            model="Hot Water Zone",
+            via_device=(DOMAIN, self.coordinator.config_entry.entry_id),
+        )
+
+
 class TadoDeviceEntity(TadoEntity):
     """Entity belonging to a specific Tado physical device (Valve/Thermostat)."""
 

--- a/custom_components/tado_hijack/helpers/optimistic_manager.py
+++ b/custom_components/tado_hijack/helpers/optimistic_manager.py
@@ -24,12 +24,18 @@ class OptimisticManager:
         self.presence_time = time.monotonic()
 
     def set_zone(
-        self, zone_id: int, overlay: bool | None, power: str | None = None
+        self,
+        zone_id: int,
+        overlay: bool | None,
+        power: str | None = None,
+        operation_mode: str | None = None,
     ) -> None:
         """Set optimistic zone overlay state."""
         data: dict[str, Any] = {"overlay": overlay, "time": time.monotonic()}
         if power is not None:
             data["power"] = power
+        if operation_mode is not None:
+            data["operation_mode"] = operation_mode
         self.zones[zone_id] = data
 
     def set_child_lock(self, serial_no: str, enabled: bool) -> None:
@@ -93,6 +99,17 @@ class OptimisticManager:
         opt = self.zones[zone_id]
         if (time.monotonic() - opt.get("time", 0)) < OPTIMISTIC_GRACE_PERIOD_S:
             return cast("str | None", opt.get("power"))
+
+        return None
+
+    def get_zone_operation_mode(self, zone_id: int) -> str | None:
+        """Return optimistic zone operation mode if not expired."""
+        if zone_id not in self.zones:
+            return None
+
+        opt = self.zones[zone_id]
+        if (time.monotonic() - opt.get("time", 0)) < OPTIMISTIC_GRACE_PERIOD_S:
+            return cast("str | None", opt.get("operation_mode"))
 
         return None
 

--- a/custom_components/tado_hijack/number.py
+++ b/custom_components/tado_hijack/number.py
@@ -42,27 +42,32 @@ async def async_setup_entry(
     coordinator: TadoDataUpdateCoordinator = entry.runtime_data
 
     entities: list[NumberEntity] = []
+    seen_offset_devices: set[str] = set()
 
     for zone in coordinator.zones_meta.values():
         # Temperature Offset per Device
         if zone.type == "HEATING":
-            entities.extend(
-                TadoNumberEntity(
-                    coordinator,
-                    device.serial_no,
-                    device.short_serial_no,
-                    device.device_type,
-                    zone.id,
-                    device.current_fw_version,
+            for device in zone.devices:
+                if CAPABILITY_INSIDE_TEMP not in (device.characteristics.capabilities or []):
+                    continue
+                # Skip devices we've already processed (can appear in multiple zones)
+                if device.serial_no in seen_offset_devices:
+                    continue
+                seen_offset_devices.add(device.serial_no)
+                entities.append(
+                    TadoNumberEntity(
+                        coordinator,
+                        device.serial_no,
+                        device.short_serial_no,
+                        device.device_type,
+                        zone.id,
+                        device.current_fw_version,
+                    )
                 )
-                for device in zone.devices
-                if CAPABILITY_INSIDE_TEMP in (device.characteristics.capabilities or [])
-            )
 
-        # Target Temperature per Zone (AC or Hot Water)
-        if zone.type in ("AIR_CONDITIONING", "HOT_WATER"):
-            # Don't fetch capabilities here to save API calls.
-            # We assume AC and Hot Water zones support target temperature control.
+        # Target Temperature per Zone (AC only)
+        # Hot water excluded - uses WaterHeaterEntity temperature control instead
+        if zone.type == "AIR_CONDITIONING":
             entities.append(
                 TadoTargetTempNumberEntity(coordinator, zone.id, zone.name, zone.type)
             )

--- a/custom_components/tado_hijack/sensor.py
+++ b/custom_components/tado_hijack/sensor.py
@@ -68,7 +68,7 @@ async def async_setup_entry(
     # Per-Zone Sensors
     for zone in coordinator.zones_meta.values():
         # Heating Power (Percentage) - Heat request for TRVs or Boiler Load for Receivers
-        if zone.type in ("HEATING", "HOT_WATER"):
+        if zone.type == "HEATING":
             entities.append(TadoHeatingPowerSensor(coordinator, zone.id, zone.name))
 
         # Humidity (Percentage)
@@ -217,3 +217,5 @@ class TadoHumiditySensor(TadoZoneEntity, SensorEntity):
         if state and state.sensor_data_points and state.sensor_data_points.humidity:
             return float(state.sensor_data_points.humidity.percentage)
         return None
+
+

--- a/custom_components/tado_hijack/services.yaml
+++ b/custom_components/tado_hijack/services.yaml
@@ -108,3 +108,52 @@ set_timer_all_zones:
           max: 30
           step: 0.1
           unit_of_measurement: "°C"
+
+set_water_heater_timer:
+  description: "Set a timer for a water heater entity with optional temperature control."
+  fields:
+    entity_id:
+      description: "Water heater entity ID (e.g. water_heater.hot_water_hot_water)."
+      required: true
+      selector:
+        entity:
+          domain: water_heater
+          integration: tado_hijack
+    duration:
+      description: "Duration in minutes after which the timer ends. If not provided, uses overlay mode."
+      selector:
+        number:
+          min: 1
+          max: 1440
+          unit_of_measurement: "min"
+    overlay:
+      description: "Termination mode: 'manual' (indefinite), 'next_block' (return to schedule at next time block), or 'presence' (until presence change). Ignored if duration is provided."
+      selector:
+        select:
+          options:
+            - "manual"
+            - "next_block"
+            - "presence"
+    operation_mode:
+      description: "Operation mode: 'auto' (resume schedule), 'heat' (manual on), or 'off'."
+      selector:
+        select:
+          options:
+            - "auto"
+            - "heat"
+            - "off"
+    power:
+      description: "Power state (ON/OFF). Ignored if operation_mode is provided."
+      selector:
+        select:
+          options:
+            - "ON"
+            - "OFF"
+    temperature:
+      description: "Target temperature (30-65°C, rounded to integer)."
+      selector:
+        number:
+          min: 30
+          max: 65
+          step: 1
+          unit_of_measurement: "°C"

--- a/custom_components/tado_hijack/switch.py
+++ b/custom_components/tado_hijack/switch.py
@@ -40,11 +40,11 @@ async def async_setup_entry(
     entities: list[SwitchEntity] = [TadoAwaySwitch(coordinator)]
 
     # Per-Zone Schedule Switches -> Zone Devices
+    # Hot water excluded - uses WaterHeaterEntity operation modes instead
     entities.extend(
         TadoZoneScheduleSwitch(coordinator, zone.id, zone.name)
         for zone in coordinator.zones_meta.values()
-        if zone.type
-        in (ZONE_TYPE_HEATING, ZONE_TYPE_AIR_CONDITIONING, ZONE_TYPE_HOT_WATER)
+        if zone.type in (ZONE_TYPE_HEATING, ZONE_TYPE_AIR_CONDITIONING)
     )
 
     # Hot Water Switches -> Zone Devices
@@ -75,14 +75,18 @@ async def async_setup_entry(
             entities.append(TadoOpenWindowSwitch(coordinator, zone.id, zone.name))
 
     # Child Lock Switches -> Device Entities
+    seen_child_lock_devices: set[str] = set()
     for zone in coordinator.zones_meta.values():
         if zone.type != "HEATING":
             continue
-        entities.extend(
-            TadoChildLockSwitch(coordinator, device, zone.id)
-            for device in zone.devices
-            if getattr(device, "child_lock_enabled", None) is not None
-        )
+        for device in zone.devices:
+            if getattr(device, "child_lock_enabled", None) is None:
+                continue
+            # Skip devices we've already processed (can appear in multiple zones)
+            if device.serial_no in seen_child_lock_devices:
+                continue
+            seen_child_lock_devices.add(device.serial_no)
+            entities.append(TadoChildLockSwitch(coordinator, device, zone.id))
 
     async_add_entities(entities)
 

--- a/custom_components/tado_hijack/translations/de.json
+++ b/custom_components/tado_hijack/translations/de.json
@@ -19,7 +19,7 @@
         "name": "Heizleistung"
       },
       "hot_water_power": {
-        "name": "Warmwasser-Leistung"
+        "name": "Leistung"
       },
       "humidity": {
         "name": "Luftfeuchtigkeit"
@@ -37,6 +37,15 @@
       },
       "bridge_connection": {
         "name": "Bridge Cloud-Verbindung"
+      },
+      "overlay": {
+        "name": "Overlay"
+      },
+      "power": {
+        "name": "Power"
+      },
+      "connectivity": {
+        "name": "Verbindung"
       }
     },
     "switch": {
@@ -138,11 +147,6 @@
             }
           }
         }
-      }
-    },
-    "water_heater": {
-      "hot_water": {
-        "name": "Warmwasser"
       }
     }
   },

--- a/custom_components/tado_hijack/translations/de.json
+++ b/custom_components/tado_hijack/translations/de.json
@@ -139,6 +139,11 @@
           }
         }
       }
+    },
+    "water_heater": {
+      "hot_water": {
+        "name": "Warmwasser"
+      }
     }
   },
   "config": {

--- a/custom_components/tado_hijack/translations/en.json
+++ b/custom_components/tado_hijack/translations/en.json
@@ -139,6 +139,11 @@
           }
         }
       }
+    },
+    "water_heater": {
+      "hot_water": {
+        "name": "Hot Water"
+      }
     }
   },
   "config": {

--- a/custom_components/tado_hijack/translations/en.json
+++ b/custom_components/tado_hijack/translations/en.json
@@ -19,7 +19,7 @@
         "name": "Heating Power"
       },
       "hot_water_power": {
-        "name": "Hot Water Power"
+        "name": "Power"
       },
       "humidity": {
         "name": "Humidity"
@@ -37,6 +37,15 @@
       },
       "bridge_connection": {
         "name": "Bridge Cloud Connection"
+      },
+      "overlay": {
+        "name": "Overlay"
+      },
+      "power": {
+        "name": "Power"
+      },
+      "connectivity": {
+        "name": "Connectivity"
       }
     },
     "switch": {
@@ -138,11 +147,6 @@
             }
           }
         }
-      }
-    },
-    "water_heater": {
-      "hot_water": {
-        "name": "Hot Water"
       }
     }
   },

--- a/custom_components/tado_hijack/water_heater.py
+++ b/custom_components/tado_hijack/water_heater.py
@@ -1,0 +1,202 @@
+"""Water heater platform for Tado Hijack."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.water_heater import (
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
+)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    TEMP_MAX_HOT_WATER,
+    TEMP_MIN_HOT_WATER,
+    TEMP_STEP_HOT_WATER,
+)
+from .entity import TadoHotWaterZoneEntity
+from .helpers.logging_utils import get_redacted_logger
+
+if TYPE_CHECKING:
+    from . import TadoConfigEntry
+    from .coordinator import TadoDataUpdateCoordinator
+
+_LOGGER = get_redacted_logger(__name__)
+
+# Tado hot water operation modes
+OPERATION_MODE_AUTO = "auto"
+OPERATION_MODE_HEAT = "heat"
+OPERATION_MODE_OFF = "off"
+
+OPERATION_MODES = [OPERATION_MODE_AUTO, OPERATION_MODE_HEAT, OPERATION_MODE_OFF]
+
+
+async def async_setup_entry(
+    hass: Any,
+    entry: TadoConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Tado hot water based on a config entry."""
+    coordinator: TadoDataUpdateCoordinator = entry.runtime_data
+    entities: list[WaterHeaterEntity] = []
+
+    # Find HOT_WATER zones
+    for zone in coordinator.zones_meta.values():
+        if zone.type == "HOT_WATER":
+            _LOGGER.info("Found hot water zone: %s (ID: %d)", zone.name, zone.id)
+            entities.append(TadoHotWater(coordinator, zone.id, zone.name))
+
+    if entities:
+        async_add_entities(entities)
+    else:
+        _LOGGER.debug("No hot water zones found")
+
+
+class TadoHotWater(TadoHotWaterZoneEntity, WaterHeaterEntity):
+    """Representation of a Tado hot water zone."""
+
+    _attr_supported_features = (
+        WaterHeaterEntityFeature.OPERATION_MODE
+        | WaterHeaterEntityFeature.TARGET_TEMPERATURE
+    )
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_operation_list = OPERATION_MODES
+    _attr_min_temp = TEMP_MIN_HOT_WATER
+    _attr_max_temp = TEMP_MAX_HOT_WATER
+    _attr_target_temperature_step = TEMP_STEP_HOT_WATER
+
+    _attr_name = None  # Use device name only, no entity suffix
+
+    def __init__(
+        self, coordinator: TadoDataUpdateCoordinator, zone_id: int, zone_name: str
+    ) -> None:
+        """Initialize Tado hot water."""
+        super().__init__(coordinator, "hot_water", zone_id, zone_name)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_hw_{zone_id}"
+        self._attr_translation_key = None  # Don't add extra name suffix
+
+    async def async_added_to_hass(self) -> None:
+        """Update temperature limits from capabilities when added to hass."""
+        await super().async_added_to_hass()
+        capabilities = await self.tado_coordinator.async_get_capabilities(self._zone_id)
+        if capabilities and capabilities.temperatures:
+            self._attr_min_temp = float(capabilities.temperatures.celsius.min)
+            self._attr_max_temp = float(capabilities.temperatures.celsius.max)
+            if capabilities.temperatures.celsius.step:
+                self._attr_target_temperature_step = float(
+                    capabilities.temperatures.celsius.step
+                )
+            self.async_write_ha_state()
+
+    @property
+    def current_operation(self) -> str:
+        """Return current operation mode."""
+        # Check optimistic state first
+        optimistic_mode = self.tado_coordinator.optimistic.get_zone_operation_mode(
+            self._zone_id
+        )
+        if optimistic_mode is not None:
+            return optimistic_mode
+
+        state = self.tado_coordinator.data.zone_states.get(str(self._zone_id))
+        if state is None:
+            return OPERATION_MODE_AUTO
+
+        # Check if there's an overlay (manual mode)
+        if getattr(state, "overlay_active", False):
+            setting = getattr(state, "setting", None)
+            if setting:
+                power = getattr(setting, "power", "ON")
+                if power == "OFF":
+                    return OPERATION_MODE_OFF
+                # If power is ON with overlay, it's heat mode
+                return OPERATION_MODE_HEAT
+
+        return OPERATION_MODE_AUTO
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current water temperature if available."""
+        state = self.tado_coordinator.data.zone_states.get(str(self._zone_id))
+        if state is None:
+            return None
+
+        sensor_data = getattr(state, "sensor_data_points", None)
+        if sensor_data:
+            inside_temp = getattr(sensor_data, "inside_temperature", None)
+            if inside_temp:
+                return getattr(inside_temp, "celsius", None)
+
+        return None
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the target water temperature.
+
+        Returns None if:
+        - Hot water is off
+        - Zone state unavailable
+        - System doesn't support temperature control (no temp in state)
+        """
+        if self.current_operation == OPERATION_MODE_OFF:
+            return None
+
+        state = self.tado_coordinator.data.zone_states.get(str(self._zone_id))
+        if state is None:
+            return None
+
+        setting = getattr(state, "setting", None)
+        if setting:
+            temp = getattr(setting, "temperature", None)
+            if temp:
+                return getattr(temp, "celsius", None)
+
+        return None
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if hot water is on."""
+        return self.current_operation != OPERATION_MODE_OFF
+
+    @property
+    def is_away_mode_on(self) -> bool:
+        """Return true if away mode is on."""
+        home_state = self.tado_coordinator.data.home_state
+        if home_state is None:
+            return False
+        return str(getattr(home_state, "presence", "")) == "AWAY"
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Set new operation mode."""
+        if operation_mode == OPERATION_MODE_OFF:
+            await self.tado_coordinator.async_set_hot_water_off(self._zone_id)
+        elif operation_mode == OPERATION_MODE_AUTO:
+            await self.tado_coordinator.async_set_hot_water_auto(self._zone_id)
+        elif operation_mode == OPERATION_MODE_HEAT:
+            await self.tado_coordinator.async_set_hot_water_heat(self._zone_id)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn hot water on (resume schedule)."""
+        await self.async_set_operation_mode(OPERATION_MODE_AUTO)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn hot water off (manual overlay)."""
+        await self.async_set_operation_mode(OPERATION_MODE_OFF)
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set new target temperature."""
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        if temperature is None:
+            return
+
+        # Round to integer for hot water (Tado requirement)
+        rounded_temp = round(float(temperature))
+
+        await self.tado_coordinator.async_set_zone_overlay(
+            self._zone_id,
+            power="ON",
+            temperature=rounded_temp,
+            overlay_type="HOT_WATER",
+        )


### PR DESCRIPTION
## Summary
Adds a dedicated `water_heater` platform for hot water zones with operation mode control and fixes optimistic state rollback when API calls fail.

## Changes
- ✅ Add new `water_heater.py` platform with operation modes (auto/heat/off)
- ✅ Add coordinator methods: `async_set_hot_water_auto()`, `async_set_hot_water_off()`, `async_set_hot_water_heat()`
- ✅ Add temperature control support for hot water zones (opentherm)
- ✅ Fix optimistic state rollback for hot water zones when API calls fail
- ✅ Add translations for water_heater platform in English and German
- ✅ Register water_heater platform in `__init__.py`

## Technical Details
- Water heater entity supports three operation modes: auto (resume schedule), heat (manual on), and off
- Temperature control with proper validation and rounding for hot water zones
- Optimistic UI updates with automatic rollback on API errors
- Coordinator methods handle hot water zone commands with proper overlay management
- Error handling prevents UI/Tado state desync when API calls fail

## Testing
- ✅ Installing on HA via HACS
- ✅ Tested turning hot water on/off via UI
- ✅ Verified optimistic updates work correctly
- ✅ Confirmed API error handling prevents UI/Tado desync
- ✅ Tested temperature control functionality
- ✅ Verified operation mode switching (auto/heat/off)

## Benefits
- Better integration with Home Assistant's water_heater domain
- Improved user experience with dedicated hot water control entity
- Prevents UI state from getting out of sync with actual Tado state
- Supports temperature control for OpenTherm-compatible boilers