### PR TITLE
fix(water_heater): resolve entity_id conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,48 @@
+## [4.0.0-dev.1](https://github.com/banter240/tado_hijack/compare/v3.1.0-dev.15...v4.0.0-dev.1) (2026-01-27)
+
+### ⚠ BREAKING CHANGES
+
+* **core:** The migration to advanced presence polling changes internal track
+handling. Config entry versions have been bumped to ensure clean state hydration.
+
+Co-authored-by: krisswiltshire30 <kriss.wiltshire@googlemail.com>
+
+### ✨ New Features
+
+* feat(core): implement advanced presence polling, adaptive quota and expert-level diagnostics
+
+This massive update stabilizes the core architecture for highly restricted API environments
+and introduces a military-grade privacy layer for diagnostic reporting.
+
+CORE ARCHITECTURE:
+- Presence Polling Evolution: Replaced legacy polling with advanced tracks using sequential
+  state handling to minimize race conditions and API overhead.
+- Adaptive Quota Brain: Implemented stateless, predictive quota calculation. The system
+  now intelligently adjusts polling intervals based on remaining 'API Gold' and daily reset
+  targets (12:01 Berlin).
+- Safety Thresholds: Integrated a dynamic buffer that prioritizes manual user actions and
+  automations over periodic background polling when quota is low.
+
+PLATFORM STABILIZATION:
+- Hot Water Restoration: Fully restored the water_heater platform. Fixed temperature
+  reporting (None for non-temp hardware) and optimized service selectors for environment
+  independence.
+- Sensor Noise Reduction: Eliminated excessive debug logging in valve state updates.
+
+EXPERT-LEVEL DIAGNOSTICS & PRIVACY:
+- Multi-Layer Anonymization: Diagnostic reports are now safe for public support.
+- Key Pseudonymization: HA Entity-IDs in JSON keys are transformed into unique hashes
+  (e.g., entity_8a3f), protecting room names while maintaining machine-readability.
+- Global PII Masking: Hard redaction for serials (VA, RU, IB), emails, geo-coordinates,
+  and cryptographic secrets (Tokens, Hashes, Salts) via intelligent Regex.
+- Contextual Redaction: Automatically identifies and replaces sensitive fields from
+  all tadoasync models (username, firstname, mobile_number, etc.).
+
+DOCUMENTATION:
+- Fully updated README covering the new consumption strategy, architecture highlights,
+  and the experts-only diagnostics system.
+- Cleaned up all internal 'v4' references to maintain public release consistency.
+
 ## [3.1.0-dev.15](https://github.com/banter240/tado_hijack/compare/v3.1.0-dev.14...v3.1.0-dev.15) (2026-01-25)
 
 ### 🐛 Bug Fixes

--- a/custom_components/tado_hijack/manifest.json
+++ b/custom_components/tado_hijack/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "tadoasync==0.2.2"
   ],
-  "version": "3.1.0-dev.15"
+  "version": "4.0.0-dev.1"
 }


### PR DESCRIPTION
- Fix translation_key override causing entity_id conflicts in water_heater
- Improve get_zone_id_from_entity to handle entity_id suffixes (_2, _3)
- Update service to work with entities that have numeric suffixes
- Add better error handling for entity resolution