### PR TITLE
Fix hot water timer

### DIFF
--- a/custom_components/tado_hijack/coordinator.py
+++ b/custom_components/tado_hijack/coordinator.py
@@ -250,7 +250,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[TadoData]):
             # Remove numeric suffix (e.g., "hot_water_2" -> "hot_water")
             base_name = (
                 entity_name.rsplit("_", 1)[0]
-                if entity_name[-1].isdigit() and "_" in entity_name
+                if entity_name and entity_name[-1].isdigit() and "_" in entity_name
                 else entity_name
             )
 
@@ -266,11 +266,10 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[TadoData]):
                         if "." in entity_entry.entity_id
                         else ""
                     )
-                    entry_base = (
-                        entry_name.rsplit("_", 1)[0]
-                        if entry_name and entry_name[-1].isdigit() and "_" in entry_name
-                        else entry_name
-                    )
+                    if entry_name and entry_name[-1].isdigit() and "_" in entry_name:
+                        entry_base = entry_name.rsplit("_", 1)[0]
+                    else:
+                        entry_base = entry_name
 
                     # Match by base name (handles _2, _3 suffixes)
                     if base_name == entry_base or entity_entry.entity_id == entity_id:

--- a/custom_components/tado_hijack/diagnostics.py
+++ b/custom_components/tado_hijack/diagnostics.py
@@ -269,7 +269,7 @@ def _get_entity_mappings(
     for entity_entry in er.async_entries_for_config_entry(ent_reg, entry_id):
         zone_id = coordinator._parse_zone_id_from_unique_id(entity_entry.unique_id)
         zone_info = "Unknown"
-        if zone_id:
+        if zone_id is not None:
             zone_info = f"Zone {zone_id}"
 
         mappings[entity_entry.entity_id] = {

--- a/custom_components/tado_hijack/services.py
+++ b/custom_components/tado_hijack/services.py
@@ -133,7 +133,7 @@ async def async_setup_services(
             return
 
         zone_id = coordinator.get_zone_id_from_entity(entity_id)
-        if not zone_id:
+        if zone_id is None:
             _LOGGER.warning("Could not resolve Tado zone for entity %s", entity_id)
             return
 

--- a/custom_components/tado_hijack/water_heater.py
+++ b/custom_components/tado_hijack/water_heater.py
@@ -176,6 +176,16 @@ class TadoHotWater(TadoHotWaterZoneEntity, WaterHeaterEntity):
         if temperature is None:
             return
 
+        # Check if this hot water zone supports temperature control
+        capabilities = self.tado_coordinator.data.capabilities.get(self._zone_id)
+        if not capabilities or not capabilities.temperatures:
+            _LOGGER.warning(
+                "Hot water zone %d does not support temperature control (no OpenTherm), "
+                "ignoring set_temperature request",
+                self._zone_id,
+            )
+            return
+
         # Round to integer for hot water (Tado requirement)
         rounded_temp = round(float(temperature))
 

--- a/custom_components/tado_hijack/water_heater.py
+++ b/custom_components/tado_hijack/water_heater.py
@@ -76,7 +76,7 @@ class TadoHotWater(TadoHotWaterZoneEntity, WaterHeaterEntity):
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_water_heater_{zone_id}"
         )
-        self._attr_translation_key = None
+        # Keep translation_key as "hot_water" for proper entity_id generation
 
     async def async_added_to_hass(self) -> None:
         """Update temperature limits from capabilities when added to hass."""

--- a/custom_components/tado_hijack/water_heater.py
+++ b/custom_components/tado_hijack/water_heater.py
@@ -76,7 +76,6 @@ class TadoHotWater(TadoHotWaterZoneEntity, WaterHeaterEntity):
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}_water_heater_{zone_id}"
         )
-        # Keep translation_key as "hot_water" for proper entity_id generation
 
     async def async_added_to_hass(self) -> None:
         """Update temperature limits from capabilities when added to hass."""


### PR DESCRIPTION
- Updated migration logic to clean up legacy hot water switches and climate entities during version 5 migration.
- Improved zone ID retrieval by adding fallback logic for water heater entities with numeric suffixes.
- Refined diagnostics to ensure proper handling of zone IDs, enhancing error reporting.
- Adjusted service setup to handle None values for zone IDs more effectively.
- Maintained translation key for water heater entities to ensure correct entity ID generation.