### PR TITLE
fix: correct broken import paths in helpers/tadox after kib folder mi…

### DIFF
--- a/custom_components/tado_hijack/helpers/tadox/discovery.py
+++ b/custom_components/tado_hijack/helpers/tadox/discovery.py
@@ -23,7 +23,7 @@ def yield_tadox_devices(
 
     """
     from ...const import DEVICE_PREFIX_BRIDGE, DEVICE_TYPE_GW01
-    from .models import HopsRoomSnapshot
+    from ...lib.tadox_models import HopsRoomSnapshot
 
     seen_devices: set[str] = set()
 

--- a/custom_components/tado_hijack/helpers/tadox/parsers.py
+++ b/custom_components/tado_hijack/helpers/tadox/parsers.py
@@ -9,7 +9,7 @@ import homeassistant.util.dt as dt_util
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from .models import TadoXDevice, TadoXZoneState
+    from ...lib.tadox_models import TadoXDevice, TadoXZoneState
 
 
 def parse_heating_power(state: TadoXZoneState | None) -> float:


### PR DESCRIPTION
…gration

- helpers/tadox/discovery.py: `from .models` → `from ...lib.tadox_models`
- helpers/tadox/parsers.py: `from .models` → `from ...lib.tadox_models`

Both files referenced a non-existent `models.py` in `helpers/tadox/`. The Pydantic models (HopsRoomSnapshot, TadoXDevice, TadoXZoneState) live in `lib/tadox_models.py` after the folder restructure.

Fixes: ModuleNotFoundError: No module named 'custom_components.tado_hijack.helpers.tadox.models'

https://claude.ai/code/session_01Q9TsvJybE5yxUJ67RcmemX