### PR TITLE
Tado X Presence mode: auto/home/away selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [5.4.0](https://github.com/banter240/tado_hijack/compare/v5.3.0...v5.4.0) (2026-04-04)
+
+### ✨ New Features
+
+* feat(presence): replace Away Mode switch with Presence Mode select entity
+
+Replaces the binary `away_mode` switch with a three-option `presence_mode` select entity supporting all Tado presence states:
+- **Home** — forces the home into Home mode (`PUT presenceLock`)
+- **Away** — forces the home into Away mode (`PUT presenceLock`)
+- **Auto** — returns presence control to Tado geofencing (`DELETE presenceLock`)
+
+The previous switch only exposed Home/Away and had no way to restore Auto mode from the UI. The new select works across both Classic (V3) and Tado X generations and integrates with the existing optimistic state and redundancy-check pipeline.
+
+---
+
 ## [5.3.0](https://github.com/banter240/tado_hijack/compare/v5.2.0...v5.3.0) (2026-04-03)
 
 ### ✨ New Features

--- a/custom_components/tado_hijack/definitions.py
+++ b/custom_components/tado_hijack/definitions.py
@@ -1697,9 +1697,9 @@ ENTITY_DEFINITIONS: Final[list[TadoEntityDefinition]] = [
         key="presence_mode",
         value_fn=lambda c: str(
             getattr(c.data.home_state, "presence", "HOME")
-        ).lower()
-        if c.data and c.data.home_state
-        else "home",
+            if c.data and c.data.home_state
+            else "HOME"
+        ).lower(),
         options_fn=lambda c: ["HOME", "AWAY", "AUTO"],
         select_option_fn=lambda c, val: c.async_set_presence_debounced(val),
         icon="mdi:home-account",

--- a/custom_components/tado_hijack/definitions.py
+++ b/custom_components/tado_hijack/definitions.py
@@ -826,6 +826,32 @@ def create_device_button(
     )
 
 
+def create_home_select(
+    key: str,
+    value_fn: Any,
+    options_fn: Any,
+    select_option_fn: Any,
+    icon: str | None = None,
+    entity_category: EntityCategory | None = None,
+    optimistic_key: str | None = None,
+    unique_id_suffix: str | None = None,
+) -> TadoEntityDefinition:
+    """Create a select entity for the Tado Home."""
+    return _create_definition(
+        key=key,
+        platform="select",
+        scope="home",
+        value_fn=value_fn,
+        options_fn=options_fn,
+        select_option_fn=select_option_fn,
+        icon=icon,
+        entity_category=entity_category,
+        optimistic_key=optimistic_key,
+        optimistic_scope="home",
+        unique_id_suffix=unique_id_suffix,
+    )
+
+
 def create_zone_select(
     key: str,
     value_fn: Any,
@@ -1667,13 +1693,17 @@ ENTITY_DEFINITIONS: Final[list[TadoEntityDefinition]] = [
         supported_zone_types={ZONE_TYPE_HEATING, ZONE_TYPE_AIR_CONDITIONING},
         unique_id_suffix="resume",
     ),
-    create_home_switch(
-        key="away_mode",
-        value_fn=lambda c: str(getattr(c.data.home_state, "presence", "")) == "AWAY",
-        turn_on_fn=lambda c: c.async_set_presence_debounced("AWAY"),
-        turn_off_fn=lambda c: c.async_set_presence_debounced("HOME"),
+    create_home_select(
+        key="presence_mode",
+        value_fn=lambda c: str(
+            getattr(c.data.home_state, "presence", "HOME")
+        ).lower()
+        if c.data and c.data.home_state
+        else "home",
+        options_fn=lambda c: ["HOME", "AWAY", "AUTO"],
+        select_option_fn=lambda c, val: c.async_set_presence_debounced(val),
+        icon="mdi:home-account",
         optimistic_key="presence",
-        optimistic_value_map={"AWAY": True, "HOME": False},
     ),
     create_home_switch(
         key="polling_active",

--- a/custom_components/tado_hijack/manifest.json
+++ b/custom_components/tado_hijack/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "tadoasync==0.2.2"
   ],
-  "version": "5.3.0"
+  "version": "5.4.0"
 }

--- a/custom_components/tado_hijack/select.py
+++ b/custom_components/tado_hijack/select.py
@@ -84,9 +84,6 @@ class TadoGenericHomeSelect(
         self._attr_optimistic_scope = definition.get("optimistic_scope")
         self._option_map: dict[str, str] = {}
         self._set_entity_id("select", definition["key"])
-        self._attr_unique_id = (
-            f"{coordinator.config_entry.entry_id}_{self._get_unique_id_suffix()}"
-        )
 
         if options_fn := definition.get("options_fn"):
             source_options = options_fn(coordinator)

--- a/custom_components/tado_hijack/select.py
+++ b/custom_components/tado_hijack/select.py
@@ -12,7 +12,13 @@ from .const import (
     CONF_ZONE_HUMIDITY_ENTITIES,
     CONF_ZONE_TEMP_ENTITIES,
 )
-from .entity import TadoGenericEntityMixin, TadoZoneEntity
+from .entity import (
+    TadoDefinitionMixin,
+    TadoGenericEntityMixin,
+    TadoHomeEntity,
+    TadoOptimisticMixin,
+    TadoZoneEntity,
+)
 from .helpers.discovery import yield_zones
 from .helpers.entity_setup import async_setup_generic_platform
 from .helpers.logging_utils import get_redacted_logger
@@ -40,6 +46,7 @@ async def async_setup_entry(
         async_add_entities,
         "select",
         {
+            "home": TadoGenericHomeSelect,
             "zone": TadoGenericZoneSelect,
         },
     )
@@ -56,6 +63,50 @@ async def async_setup_entry(
         )
     if source_entities:
         async_add_entities(source_entities)
+
+
+class TadoGenericHomeSelect(
+    TadoGenericEntityMixin, TadoOptimisticMixin, TadoHomeEntity, SelectEntity
+):
+    """Generic select for Home scope."""
+
+    def __init__(
+        self,
+        coordinator: TadoDataUpdateCoordinator,
+        definition: TadoEntityDefinition,
+    ) -> None:
+        """Initialize the generic home select."""
+        TadoHomeEntity.__init__(
+            self, coordinator, cast(str, definition["translation_key"])
+        )
+        TadoDefinitionMixin.__init__(self, definition)
+        self._attr_optimistic_key = definition.get("optimistic_key")
+        self._attr_optimistic_scope = definition.get("optimistic_scope")
+        self._option_map: dict[str, str] = {}
+        self._set_entity_id("select", definition["key"])
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_{self._get_unique_id_suffix()}"
+        )
+
+        if options_fn := definition.get("options_fn"):
+            source_options = options_fn(coordinator)
+            if source_options:
+                self._option_map = {opt.lower(): opt for opt in source_options}
+                self._attr_options = [opt.lower() for opt in source_options]
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected option."""
+        val = self._resolve_state()
+        if val is not None:
+            return str(val).lower()
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        api_value = self._option_map.get(option, option.upper())
+        await self._async_select_option(api_value)
+        self.async_write_ha_state()
 
 
 class TadoGenericZoneSelect(TadoZoneEntity, TadoGenericEntityMixin, SelectEntity):

--- a/custom_components/tado_hijack/translations/de.json
+++ b/custom_components/tado_hijack/translations/de.json
@@ -178,9 +178,6 @@
       }
     },
     "switch": {
-      "away_mode": {
-        "name": "Abwesend-Modus"
-      },
       "polling_active": {
         "name": "Globales Polling"
       },
@@ -256,6 +253,14 @@
       }
     },
     "select": {
+      "presence_mode": {
+        "name": "Anwesenheitsmodus",
+        "state": {
+          "home": "Zuhause",
+          "away": "Abwesend",
+          "auto": "Automatisch"
+        }
+      },
       "zone_temp_source": {
         "name": "Temperaturquelle"
       },

--- a/custom_components/tado_hijack/translations/en.json
+++ b/custom_components/tado_hijack/translations/en.json
@@ -178,9 +178,6 @@
       }
     },
     "switch": {
-      "away_mode": {
-        "name": "Away Mode"
-      },
       "polling_active": {
         "name": "Global Polling"
       },
@@ -256,6 +253,14 @@
       }
     },
     "select": {
+      "presence_mode": {
+        "name": "Presence Mode",
+        "state": {
+          "home": "Home",
+          "away": "Away",
+          "auto": "Auto"
+        }
+      },
       "zone_temp_source": {
         "name": "Temperature Source"
       },


### PR DESCRIPTION
## What does this PR do?

Replaces the binary `away_mode` switch with a three-option `presence_mode` select entity, exposing all three Tado presence states: **Home**, **Away**, and **Auto**.
Auto mode only works when Auto-Assist subscription is active. This change is useful if you want to override the automatic presence detection in the Tado app. And afterwards set back to auto. Update your automations to use the new selector!

action: select.select_option
target:
  entity_id: select.tado_****_presence_mode
data:
  option: Home

The previous switch could only toggle between Home and Away — there was no way to restore Tado's automatic geofencing (Auto) from the UI. The new select maps directly to the underlying API:
- **Home / Away** → `PUT /api/v2/homes/{id}/presenceLock`
- **Auto** → `DELETE /api/v2/homes/{id}/presenceLock`

Integrates with the existing optimistic state manager and redundancy checker unchanged, since both are string-based.

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Affected Generation(s)

- [ ] V2 - GW Bridge
- [ ] V3 Classic (HomeKit)
- [ ] Tado X (Matter)
- [x] All / not generation-specific

## Testing

Tested with Tado X / Tado V3

## Checklist

- [ ] Pre-commit passes (`ruff`, `mypy`, `hassfest`, `HACS`)
- [x] No debug logging left in
- [x] Tested on real hardware
