### PR TITLE
feat(sensors): zone mode and home mode sensors

### DIFF
--- a/custom_components/tado_hijack/const.py
+++ b/custom_components/tado_hijack/const.py
@@ -140,6 +140,13 @@ ZONE_TYPE_HEATING: Final = "HEATING"
 ZONE_TYPE_HOT_WATER: Final = "HOT_WATER"
 ZONE_TYPE_AIR_CONDITIONING: Final = "AIR_CONDITIONING"
 
+# Zone Mode States
+ZONE_MODE_SCHEDULE: Final = "schedule"
+ZONE_MODE_OFF: Final = "off"
+ZONE_MODE_BOOST: Final = "boost"
+ZONE_MODE_MANUAL: Final = "manual"
+ZONE_MODE_MIXED: Final = "mixed"
+
 # Power States
 POWER_ON: Final = "ON"
 POWER_OFF: Final = "OFF"

--- a/custom_components/tado_hijack/definitions.py
+++ b/custom_components/tado_hijack/definitions.py
@@ -70,6 +70,7 @@ from .const import (
     TEMP_MAX_HOT_WATER_OVERRIDE,
     TEMP_MIN_AC,
     TEMP_MIN_HOT_WATER,
+    ZONE_MODE_MIXED,
     ZONE_TYPE_AIR_CONDITIONING,
     ZONE_TYPE_HEATING,
     ZONE_TYPE_HOT_WATER,
@@ -931,7 +932,7 @@ def _parse_home_zone_mode(c: Any) -> str | None:
     modes = {parse_fn(zone_states.get(str(zid))) for zid in relevant_ids} - {None}
     if not modes:
         return None
-    return next(iter(modes)) if len(modes) == 1 else "mixed"
+    return next(iter(modes)) if len(modes) == 1 else ZONE_MODE_MIXED
 
 
 ENTITY_DEFINITIONS: Final[list[TadoEntityDefinition]] = [
@@ -1203,6 +1204,7 @@ ENTITY_DEFINITIONS: Final[list[TadoEntityDefinition]] = [
         ),
         device_class=SensorDeviceClass.ENUM,
         icon="mdi:thermostat",
+        supported_zone_types={ZONE_TYPE_HEATING, ZONE_TYPE_AIR_CONDITIONING},
         unique_id_suffix="mode",
     ),
     create_zone_sensor(

--- a/custom_components/tado_hijack/definitions.py
+++ b/custom_components/tado_hijack/definitions.py
@@ -923,7 +923,7 @@ def _parse_home_zone_mode(c: Any) -> str | None:
     relevant_ids = [
         zid
         for zid, zmeta in c.zones_meta.items()
-        if zmeta.type in {ZONE_TYPE_HEATING, ZONE_TYPE_AIR_CONDITIONING}
+        if getattr(zmeta, "type", ZONE_TYPE_HEATING) in {ZONE_TYPE_HEATING, ZONE_TYPE_AIR_CONDITIONING}
     ]
     if not relevant_ids:
         return None

--- a/custom_components/tado_hijack/definitions.py
+++ b/custom_components/tado_hijack/definitions.py
@@ -910,11 +910,41 @@ def create_zone_sensor(
     )
 
 
+def _parse_home_zone_mode(c: Any) -> str | None:
+    """Return the combined zone mode across all heating/AC zones."""
+    zone_states = c.data.zone_states
+    if not zone_states:
+        return None
+
+    parse_fn = (
+        tadox_parsers.parse_zone_mode if c.generation == GEN_X else v3_parsers.parse_zone_mode
+    )
+
+    relevant_ids = [
+        zid
+        for zid, zmeta in c.zones_meta.items()
+        if zmeta.type in {ZONE_TYPE_HEATING, ZONE_TYPE_AIR_CONDITIONING}
+    ]
+    if not relevant_ids:
+        return None
+
+    modes = {parse_fn(zone_states.get(str(zid))) for zid in relevant_ids} - {None}
+    if not modes:
+        return None
+    return next(iter(modes)) if len(modes) == 1 else "mixed"
+
+
 ENTITY_DEFINITIONS: Final[list[TadoEntityDefinition]] = [
     create_diagnostic_sensor(
         key="api_status",
         value_fn=lambda c: str(c.data.api_status),
         device_class=SensorDeviceClass.ENUM,
+    ),
+    create_home_sensor(
+        key="home_mode",
+        value_fn=_parse_home_zone_mode,
+        device_class=SensorDeviceClass.ENUM,
+        icon="mdi:home-thermometer",
     ),
     create_diagnostic_sensor(
         key="tado_generation",

--- a/custom_components/tado_hijack/definitions.py
+++ b/custom_components/tado_hijack/definitions.py
@@ -1155,6 +1155,27 @@ ENTITY_DEFINITIONS: Final[list[TadoEntityDefinition]] = [
         unique_id_suffix="pwr",
     ),
     create_zone_sensor(
+        key="zone_mode",
+        supported_generations={GEN_CLASSIC},
+        value_fn=lambda c, zid: v3_parsers.parse_zone_mode(
+            c.data.zone_states.get(str(zid))
+        ),
+        device_class=SensorDeviceClass.ENUM,
+        icon="mdi:thermostat",
+        supported_zone_types={ZONE_TYPE_HEATING, ZONE_TYPE_AIR_CONDITIONING},
+        unique_id_suffix="mode",
+    ),
+    create_zone_sensor(
+        key="zone_mode",
+        supported_generations={GEN_X},
+        value_fn=lambda c, zid: tadox_parsers.parse_zone_mode(
+            c.data.zone_states.get(str(zid))
+        ),
+        device_class=SensorDeviceClass.ENUM,
+        icon="mdi:thermostat",
+        unique_id_suffix="mode",
+    ),
+    create_zone_sensor(
         key="humidity",
         value_fn=lambda c, zid: _get_zone_sensor_data(c, zid, "humidity"),
         unit="%",

--- a/custom_components/tado_hijack/helpers/parsers.py
+++ b/custom_components/tado_hijack/helpers/parsers.py
@@ -5,6 +5,13 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any
 
+from ..const import (
+    POWER_OFF,
+    ZONE_MODE_BOOST,
+    ZONE_MODE_MANUAL,
+    ZONE_MODE_OFF,
+    ZONE_MODE_SCHEDULE,
+)
 from ..models import RateLimit
 
 if TYPE_CHECKING:
@@ -58,6 +65,24 @@ def get_ac_capabilities(capabilities: Capabilities) -> dict[str, set[str]]:
         "vertical_swings": v_swings,
         "horizontal_swings": h_swings,
     }
+
+
+def resolve_zone_mode(overlay_active: bool, power: str, is_boost: bool) -> str:
+    """Resolve zone operating mode from overlay state.
+
+    Args:
+        overlay_active: Whether a manual overlay is active.
+        power: Zone power state ("ON" or "OFF").
+        is_boost: Whether the zone is currently in boost mode.
+
+    """
+    if not overlay_active:
+        return ZONE_MODE_SCHEDULE
+    if power == POWER_OFF:
+        return ZONE_MODE_OFF
+    if is_boost:
+        return ZONE_MODE_BOOST
+    return ZONE_MODE_MANUAL
 
 
 def parse_schedule_temperature(state: Any) -> float | None:

--- a/custom_components/tado_hijack/helpers/tadov3/parsers.py
+++ b/custom_components/tado_hijack/helpers/tadov3/parsers.py
@@ -19,6 +19,7 @@ from ..climate_physics import (
 from ..climate_physics import (
     compute_dew_point as _compute_dew_point,
 )
+from ..parsers import resolve_zone_mode
 
 # Re-export for callers that import it directly (e.g. definitions.py uses
 # compute_absolute_humidity via this module).
@@ -191,14 +192,13 @@ def parse_zone_mode(state: Any) -> str | None:
     """Return the current operating mode of a v3 zone."""
     if not state:
         return None
-    if not getattr(state, "overlay_active", False):
-        return "schedule"
     setting = getattr(state, "setting", None)
     power = getattr(setting, "power", "OFF") if setting else "OFF"
-    if power == "OFF":
-        return "off"
     temp_obj = getattr(setting, "temperature", None) if setting else None
     celsius = getattr(temp_obj, "celsius", None) if temp_obj else None
-    if celsius is not None and abs(celsius - BOOST_MODE_TEMP) <= TEMP_TOLERANCE:
-        return "boost"
-    return "manual"
+    is_boost = celsius is not None and abs(celsius - BOOST_MODE_TEMP) <= TEMP_TOLERANCE
+    return resolve_zone_mode(
+        overlay_active=getattr(state, "overlay_active", False),
+        power=power,
+        is_boost=is_boost,
+    )

--- a/custom_components/tado_hijack/helpers/tadov3/parsers.py
+++ b/custom_components/tado_hijack/helpers/tadov3/parsers.py
@@ -184,3 +184,20 @@ def parse_mold_risk_level(state: Any) -> str | None:
         return None
     temp, rh = values
     return compute_mold_risk_level(temp, rh)
+
+
+def parse_zone_mode(state: Any) -> str | None:
+    """Return the current operating mode of a v3 zone."""
+    if not state:
+        return None
+    if not getattr(state, "overlay_active", False):
+        return "schedule"
+    setting = getattr(state, "setting", None)
+    power = getattr(setting, "power", "OFF") if setting else "OFF"
+    if power == "OFF":
+        return "off"
+    temp_obj = getattr(setting, "temperature", None) if setting else None
+    celsius = getattr(temp_obj, "celsius", None) if temp_obj else None
+    if celsius is not None and abs(celsius - 25.0) <= 0.1:
+        return "boost"
+    return "manual"

--- a/custom_components/tado_hijack/helpers/tadov3/parsers.py
+++ b/custom_components/tado_hijack/helpers/tadov3/parsers.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import homeassistant.util.dt as dt_util
 
+from ...const import BOOST_MODE_TEMP, TEMP_TOLERANCE
 from ..climate_physics import (
     VENTILATION_AH_THRESHOLD as _DEFAULT_VENTILATION_AH_THRESHOLD,
 )
@@ -198,6 +199,6 @@ def parse_zone_mode(state: Any) -> str | None:
         return "off"
     temp_obj = getattr(setting, "temperature", None) if setting else None
     celsius = getattr(temp_obj, "celsius", None) if temp_obj else None
-    if celsius is not None and abs(celsius - 25.0) <= 0.1:
+    if celsius is not None and abs(celsius - BOOST_MODE_TEMP) <= TEMP_TOLERANCE:
         return "boost"
     return "manual"

--- a/custom_components/tado_hijack/helpers/tadox/parsers.py
+++ b/custom_components/tado_hijack/helpers/tadox/parsers.py
@@ -163,3 +163,16 @@ def parse_ventilation_recommended(
     indoor_ah = compute_absolute_humidity(temp_celsius, rh)
     outdoor_ah = compute_absolute_humidity(outdoor_temp, outdoor_rh)
     return compute_ventilation_beneficial(indoor_ah, outdoor_ah, threshold)
+
+
+def parse_zone_mode(state: TadoXZoneState | None) -> str | None:
+    """Return the current operating mode of a Tado X zone."""
+    if not state:
+        return None
+    if not state.overlay_active:
+        return "schedule"
+    if state.setting.power == "OFF":
+        return "off"
+    if state.boost_mode is not None:
+        return "boost"
+    return "manual"

--- a/custom_components/tado_hijack/helpers/tadox/parsers.py
+++ b/custom_components/tado_hijack/helpers/tadox/parsers.py
@@ -17,6 +17,7 @@ from ..climate_physics import (
 from ..climate_physics import (
     compute_dew_point as _compute_dew_point,
 )
+from ..parsers import resolve_zone_mode
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -169,10 +170,8 @@ def parse_zone_mode(state: TadoXZoneState | None) -> str | None:
     """Return the current operating mode of a Tado X zone."""
     if not state:
         return None
-    if not state.overlay_active:
-        return "schedule"
-    if state.setting.power == "OFF":
-        return "off"
-    if state.boost_mode is not None:
-        return "boost"
-    return "manual"
+    return resolve_zone_mode(
+        overlay_active=state.overlay_active,
+        power=state.setting.power,
+        is_boost=state.boost_mode is not None,
+    )

--- a/custom_components/tado_hijack/translations/de.json
+++ b/custom_components/tado_hijack/translations/de.json
@@ -153,7 +153,7 @@
         }
       },
       "home_mode": {
-        "name": "Haussenmodus",
+        "name": "Hausmodus",
         "state": {
           "schedule": "Zeitplan",
           "off": "Aus",

--- a/custom_components/tado_hijack/translations/de.json
+++ b/custom_components/tado_hijack/translations/de.json
@@ -142,6 +142,15 @@
       },
       "scan_interval": {
         "name": "Abfrageintervall"
+      },
+      "zone_mode": {
+        "name": "Zonenmodus",
+        "state": {
+          "schedule": "Zeitplan",
+          "off": "Aus",
+          "boost": "Boost",
+          "manual": "Manuell"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/tado_hijack/translations/de.json
+++ b/custom_components/tado_hijack/translations/de.json
@@ -151,6 +151,16 @@
           "boost": "Boost",
           "manual": "Manuell"
         }
+      },
+      "home_mode": {
+        "name": "Haussenmodus",
+        "state": {
+          "schedule": "Zeitplan",
+          "off": "Aus",
+          "boost": "Boost",
+          "manual": "Manuell",
+          "mixed": "Gemischt"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/tado_hijack/translations/en.json
+++ b/custom_components/tado_hijack/translations/en.json
@@ -142,6 +142,15 @@
       },
       "scan_interval": {
         "name": "Scan Interval"
+      },
+      "zone_mode": {
+        "name": "Zone Mode",
+        "state": {
+          "schedule": "Schedule",
+          "off": "Off",
+          "boost": "Boost",
+          "manual": "Manual"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/tado_hijack/translations/en.json
+++ b/custom_components/tado_hijack/translations/en.json
@@ -151,6 +151,16 @@
           "boost": "Boost",
           "manual": "Manual"
         }
+      },
+      "home_mode": {
+        "name": "Home Mode",
+        "state": {
+          "schedule": "Schedule",
+          "off": "Off",
+          "boost": "Boost",
+          "manual": "Manual",
+          "mixed": "Mixed"
+        }
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
## What does this PR do?

<head></head><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Summary</h3><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><li>Add a<span> </span><strong>Zone Mode</strong><span> </span>sensor per zone (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">schedule</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">off</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">boost</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">manual</code>)</li><li>Add a<span> </span><strong>Home Mode</strong><span> </span>sensor on the hub device aggregating all heating/AC zones (<code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">schedule</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">off</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">boost</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">manual</code>,<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mixed</code>)</li></ul><h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">How it works</h3><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><strong>Zone Mode</strong> (per zone, heating + AC)</p>
State | Condition
-- | --
schedule | No overlay active
off | Overlay active, power OFF
boost | Overlay active, power ON, at 25 °C (Classic) / boostMode field set (Tado X)
manual | Overlay active, power ON, any other temperature

<p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><strong>Home Mode</strong> (hub device)</p><ul style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; padding-inline-start: 2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;"><li>Collects the zone mode from every heating/AC zone</li><li>If all zones share the same state → reports that state</li><li>If zones differ → reports<span> </span><code style="font-family: monospace; color: rgb(140, 140, 140); background-color: rgb(38, 38, 38); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">mixed</code></li></ul><p style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: initial; text-decoration-style: initial; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(191, 191, 191); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-variant-ligatures: normal; background-color: rgb(25, 26, 27); text-decoration-color: initial;">Mirrors the scope of the existing global action buttons: Resume All Schedules, Boost All Zones, Turn Off All Zones. </p>


## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Affected Generation(s)

- [ ] V2 - GW Bridge
- [ ] V3 Classic (HomeKit)
- [ ] Tado X (Matter)
- [x] All / not generation-specific

## Testing

Tested on Tado X and Tado V3

## Checklist

- [x] Pre-commit passes (`ruff`, `mypy`, `hassfest`, `HACS`)
- [x] No debug logging left in
- [x] Tested on real hardware or described why not applicable
