### PR TITLE
Add timetable selectors and resfresh buttons per zone

### DIFF
--- a/custom_components/tado_hijack/coordinator.py
+++ b/custom_components/tado_hijack/coordinator.py
@@ -376,6 +376,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
 
             self.zones_meta = self.data_manager.zones_meta
             self.devices_meta = self.data_manager.devices_meta
+            self.timetable_cache: dict[int, dict] = self.data_manager.timetable_cache
 
             from .helpers.discovery import get_bridges
 
@@ -1105,6 +1106,45 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             enabled,
             rollback_context=old_val,
         )
+
+    async def async_set_timetable(self, zone_id: int, timetable_type: str) -> None:
+        """Set the active timetable schedule type for a zone.
+
+        timetable_type: "ONE_DAY" | "THREE_DAY" | "SEVEN_DAY"
+        Goes through the command queue (1 API call, debounced & merged).
+        """
+        type_to_id = {"ONE_DAY": 0, "THREE_DAY": 1, "SEVEN_DAY": 2}
+        timetable_id = type_to_id.get(timetable_type)
+        if timetable_id is None:
+            _LOGGER.error("Invalid timetable type: %s", timetable_type)
+            return
+
+        # Optimistically update local cache for immediate UI feedback
+        entry = {"id": timetable_id, "type": timetable_type}
+        self.timetable_cache[zone_id] = entry
+        self.data_manager.timetable_cache[zone_id] = entry
+        self.async_update_listeners()
+
+        self.api_manager.queue_command(
+            f"set_timetable_{zone_id}",
+            TadoCommand(
+                CommandType.SET_TIMETABLE,
+                zone_id=zone_id,
+                data={"zone_id": zone_id, "timetable_id": timetable_id},
+            ),
+        )
+
+    async def async_refresh_timetable(self, zone_id: int) -> None:
+        """Refresh the active timetable for a zone from the API."""
+        _LOGGER.info("Refreshing timetable for zone %s", zone_id)
+        try:
+            entry = await self._tado.get_active_timetable(zone_id)
+            self.timetable_cache[zone_id] = entry
+            self.data_manager.timetable_cache[zone_id] = entry
+            self.async_update_listeners()
+            _LOGGER.debug("Timetable refreshed for zone %s: %s", zone_id, entry)
+        except Exception as err:
+            _LOGGER.error("Failed to refresh timetable for zone %s: %s", zone_id, err)
 
     async def async_set_open_window_detection(
         self, zone_id: int, enabled: bool, timeout_seconds: int | None = None

--- a/custom_components/tado_hijack/coordinator.py
+++ b/custom_components/tado_hijack/coordinator.py
@@ -273,6 +273,16 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
                 self._last_quota_reset = last_reset
             self._schedule_reset_poll()
 
+        timetable_data = await self.storage.async_get("timetable_cache")
+        if timetable_data:
+            restored = {int(k): v for k, v in timetable_data.items()}
+            self.data_manager.timetable_cache.update(restored)
+            _LOGGER.debug(
+                "Restored timetable cache for %d zone(s): %s",
+                len(restored),
+                restored,
+            )
+
     def _save_reset_tracker(self) -> None:
         """Persist reset tracker state to storage."""
         self.hass.async_create_task(
@@ -1107,6 +1117,15 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             rollback_context=old_val,
         )
 
+    def _save_timetable_cache(self) -> None:
+        """Persist timetable cache to storage."""
+        self.hass.async_create_task(
+            self.storage.async_update(
+                "timetable_cache",
+                {str(k): v for k, v in self.timetable_cache.items()},
+            )
+        )
+
     async def async_set_timetable(self, zone_id: int, timetable_type: str) -> None:
         """Set the active timetable schedule type for a zone.
 
@@ -1124,6 +1143,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
         self.timetable_cache[zone_id] = entry
         self.data_manager.timetable_cache[zone_id] = entry
         self.async_update_listeners()
+        self._save_timetable_cache()
 
         self.api_manager.queue_command(
             f"set_timetable_{zone_id}",
@@ -1142,9 +1162,57 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
             self.timetable_cache[zone_id] = entry
             self.data_manager.timetable_cache[zone_id] = entry
             self.async_update_listeners()
+            self._save_timetable_cache()
             _LOGGER.debug("Timetable refreshed for zone %s: %s", zone_id, entry)
         except Exception as err:
             _LOGGER.error("Failed to refresh timetable for zone %s: %s", zone_id, err)
+
+    async def async_refresh_all_timetables(self) -> None:
+        """Refresh the active timetable for all compatible zones (HEATING + HOT_WATER, GEN_CLASSIC only)."""
+        if self.generation != GEN_CLASSIC:
+            _LOGGER.debug("async_refresh_all_timetables: skipped (not GEN_CLASSIC)")
+            return
+
+        from .helpers.zone_utils import get_zone_type
+
+        zone_ids = [
+            zone_id
+            for zone_id, zone in self.zones_meta.items()
+            if get_zone_type(zone) in (ZONE_TYPE_HEATING, ZONE_TYPE_HOT_WATER)
+        ]
+
+        if not zone_ids:
+            _LOGGER.debug("async_refresh_all_timetables: no compatible zones found")
+            return
+
+        _LOGGER.info("Refreshing timetables for %d zone(s): %s", len(zone_ids), zone_ids)
+        for zone_id in zone_ids:
+            await self.async_refresh_timetable(zone_id)
+
+    async def async_set_timetable_all_zones(self, timetable_type: str) -> None:
+        """Set the timetable type for all compatible zones (HEATING + HOT_WATER, GEN_CLASSIC only)."""
+        if self.generation != GEN_CLASSIC:
+            _LOGGER.debug("async_set_timetable_all_zones: skipped (not GEN_CLASSIC)")
+            return
+
+        from .helpers.zone_utils import get_zone_type
+
+        zone_ids = [
+            zone_id
+            for zone_id, zone in self.zones_meta.items()
+            if get_zone_type(zone) in (ZONE_TYPE_HEATING, ZONE_TYPE_HOT_WATER)
+        ]
+
+        if not zone_ids:
+            _LOGGER.debug("async_set_timetable_all_zones: no compatible zones found")
+            return
+
+        _LOGGER.info(
+            "Setting timetable type '%s' for %d zone(s): %s",
+            timetable_type, len(zone_ids), zone_ids,
+        )
+        for zone_id in zone_ids:
+            await self.async_set_timetable(zone_id, timetable_type)
 
     async def async_set_open_window_detection(
         self, zone_id: int, enabled: bool, timeout_seconds: int | None = None

--- a/custom_components/tado_hijack/definitions.py
+++ b/custom_components/tado_hijack/definitions.py
@@ -760,6 +760,7 @@ def create_home_button(
     entity_category: EntityCategory | None = None,
     translation_key: str | None = None,
     unique_id_suffix: str | None = None,
+    is_supported_fn: Any | None = None,
 ) -> TadoEntityDefinition:
     """Create a button for the Tado Home."""
     return _create_definition(
@@ -772,6 +773,7 @@ def create_home_button(
         entity_category=entity_category,
         translation_key=translation_key,
         unique_id_suffix=unique_id_suffix,
+        is_supported_fn=is_supported_fn,
     )
 
 
@@ -835,6 +837,7 @@ def create_home_select(
     icon: str | None = None,
     entity_category: EntityCategory | None = None,
     unique_id_suffix: str | None = None,
+    is_supported_fn: Any | None = None,
 ) -> TadoEntityDefinition:
     """Create a select entity for the Tado Home."""
     return _create_definition(
@@ -847,6 +850,7 @@ def create_home_select(
         icon=icon,
         entity_category=entity_category,
         unique_id_suffix=unique_id_suffix,
+        is_supported_fn=is_supported_fn,
     )
 
 
@@ -1895,14 +1899,26 @@ ENTITY_DEFINITIONS: Final[list[TadoEntityDefinition]] = [
         optimistic_key="horizontal_swing",
         supported_generations={GEN_CLASSIC},
     ),
-    create_zone_button(
-        key="refresh_timetable",
-        press_fn=lambda c, zid: c.async_refresh_timetable(zid),
+    create_home_select(
+        key="timetable_type_all_zones",
+        value_fn=lambda c: (
+            next(iter(c.timetable_cache.values()), {}).get("type", "ONE_DAY").lower()
+            if hasattr(c, "timetable_cache") and c.timetable_cache
+            else "one_day"
+        ),
+        options=["one_day", "three_day", "seven_day"],
+        select_option_fn=lambda c, val: c.async_set_timetable_all_zones(val.upper()),
+        icon="mdi:calendar-week",
+        entity_category=EntityCategory.CONFIG,
+        unique_id_suffix="timetable_type_all",
+        is_supported_fn=lambda c: c.generation == GEN_CLASSIC,
+    ),
+    create_home_button(
+        key="refresh_all_timetables",
+        press_fn=lambda c: c.async_refresh_all_timetables(),
         icon="mdi:calendar-refresh",
         entity_category=EntityCategory.CONFIG,
-        supported_zone_types={ZONE_TYPE_HEATING, ZONE_TYPE_HOT_WATER},
-        supported_generations={GEN_CLASSIC},
-        unique_id_suffix="refresh_timetable",
+        is_supported_fn=lambda c: c.generation == GEN_CLASSIC,
     ),
     create_zone_select(
         key="timetable_type",
@@ -1920,5 +1936,14 @@ ENTITY_DEFINITIONS: Final[list[TadoEntityDefinition]] = [
         supported_zone_types={ZONE_TYPE_HEATING, ZONE_TYPE_HOT_WATER},
         supported_generations={GEN_CLASSIC},
         unique_id_suffix="timetable_type",
+    ),
+    create_zone_button(
+        key="refresh_timetable",
+        press_fn=lambda c, zid: c.async_refresh_timetable(zid),
+        icon="mdi:calendar-refresh",
+        entity_category=EntityCategory.CONFIG,
+        supported_zone_types={ZONE_TYPE_HEATING, ZONE_TYPE_HOT_WATER},
+        supported_generations={GEN_CLASSIC},
+        unique_id_suffix="refresh_timetable",
     ),
 ]

--- a/custom_components/tado_hijack/definitions.py
+++ b/custom_components/tado_hijack/definitions.py
@@ -1895,4 +1895,30 @@ ENTITY_DEFINITIONS: Final[list[TadoEntityDefinition]] = [
         optimistic_key="horizontal_swing",
         supported_generations={GEN_CLASSIC},
     ),
+    create_zone_button(
+        key="refresh_timetable",
+        press_fn=lambda c, zid: c.async_refresh_timetable(zid),
+        icon="mdi:calendar-refresh",
+        entity_category=EntityCategory.CONFIG,
+        supported_zone_types={ZONE_TYPE_HEATING, ZONE_TYPE_HOT_WATER},
+        supported_generations={GEN_CLASSIC},
+        unique_id_suffix="refresh_timetable",
+    ),
+    create_zone_select(
+        key="timetable_type",
+        value_fn=lambda c, zid: (
+            c.timetable_cache.get(zid, {}).get("type", "ONE_DAY").lower()
+            if hasattr(c, "timetable_cache")
+            else None
+        ),
+        options_fn=lambda c, zid: ["one_day", "three_day", "seven_day"],
+        select_option_fn=lambda c, zid, val: c.async_set_timetable(
+            zid, val.upper()
+        ),
+        icon="mdi:calendar-week",
+        entity_category=EntityCategory.CONFIG,
+        supported_zone_types={ZONE_TYPE_HEATING, ZONE_TYPE_HOT_WATER},
+        supported_generations={GEN_CLASSIC},
+        unique_id_suffix="timetable_type",
+    ),
 ]

--- a/custom_components/tado_hijack/helpers/api_manager.py
+++ b/custom_components/tado_hijack/helpers/api_manager.py
@@ -302,6 +302,7 @@ class TadoApiManager:
                     merged.get("dazzle_modes"),
                     merged.get("early_starts"),
                     merged.get("open_windows"),
+                    merged.get("timetables"),
                     merged.get("identifies"),
                 ]
             )

--- a/custom_components/tado_hijack/helpers/client.py
+++ b/custom_components/tado_hijack/helpers/client.py
@@ -156,3 +156,31 @@ class TadoHijackClient(Tado):
             f"devices/{serial_no}/identify",
             method=HttpMethod.POST,
         )
+
+    async def get_active_timetable(self, zone_id: int) -> dict[str, Any]:
+        """Get the active timetable type for a zone.
+
+        Returns a dict with 'id' (int) and 'type' (str) fields.
+        Possible types:
+          - ONE_DAY   : same schedule every day (Mon-Sun)
+          - THREE_DAY : Mon-Fri / Sat / Sun
+          - SEVEN_DAY : one schedule per day of the week
+        """
+        response = await self._request(
+            f"homes/{self._home_id}/zones/{zone_id}/schedule/activeTimetable"
+        )
+        return cast(dict[str, Any], orjson.loads(response))
+
+    async def set_active_timetable(self, zone_id: int, timetable_id: int) -> None:
+        """Set the active timetable for a zone.
+
+        timetable_id values:
+          0 = ONE_DAY   (Mon-Sun)
+          1 = THREE_DAY (Mon-Fri / Sat / Sun)
+          2 = SEVEN_DAY (one per day)
+        """
+        await self._request(
+            f"homes/{self._home_id}/zones/{zone_id}/schedule/activeTimetable",
+            data={"id": timetable_id},
+            method=HttpMethod.PUT,
+        )

--- a/custom_components/tado_hijack/helpers/command_merger.py
+++ b/custom_components/tado_hijack/helpers/command_merger.py
@@ -23,6 +23,7 @@ class CommandMerger:
         self.dazzle_modes: dict[int, bool] = {}
         self.early_starts: dict[int, bool] = {}
         self.open_windows: dict[int, Any] = {}
+        self.timetables: dict[int, int] = {}  # zone_id -> timetable_id
         self.identifies: set[str] = set()
         self.presence: str | None = None
         self.old_presence: str | None = None
@@ -46,6 +47,7 @@ class CommandMerger:
             CommandType.SET_DAZZLE: self._merge_dazzle,
             CommandType.SET_EARLY_START: self._merge_early_start,
             CommandType.SET_OPEN_WINDOW: self._merge_open_window,
+            CommandType.SET_TIMETABLE: self._merge_timetable,
             CommandType.IDENTIFY: self._merge_identify,
             CommandType.SET_PRESENCE: self._merge_presence,
             CommandType.RESUME_SCHEDULE: self._merge_resume,
@@ -130,6 +132,11 @@ class CommandMerger:
             store_full_data=True,
         )
 
+    def _merge_timetable(self, cmd: TadoCommand) -> None:
+        """Merge timetable command — last write wins per zone."""
+        if cmd.data and "zone_id" in cmd.data and "timetable_id" in cmd.data:
+            self.timetables[int(cmd.data["zone_id"])] = int(cmd.data["timetable_id"])
+
     def _merge_identify(self, cmd: TadoCommand) -> None:
         if cmd.data and "serial" in cmd.data:
             self.identifies.add(str(cmd.data["serial"]))
@@ -192,6 +199,7 @@ class CommandMerger:
             "dazzle_modes": self.dazzle_modes,
             "early_starts": self.early_starts,
             "open_windows": self.open_windows,
+            "timetables": self.timetables,
             "identifies": self.identifies,
             "presence": self.presence,
             "old_presence": self.old_presence,

--- a/custom_components/tado_hijack/helpers/data_manager.py
+++ b/custom_components/tado_hijack/helpers/data_manager.py
@@ -66,6 +66,7 @@ class TadoDataManager:
         self.capabilities_cache: dict[int, Any] = {}
         self.offsets_cache: dict[str, TemperatureOffset] = {}
         self.away_cache: dict[int, float] = {}
+        self.timetable_cache: dict[int, dict[str, Any]] = {}  # zone_id -> {id, type}
         self._capability_locks: dict[int, asyncio.Lock] = {}
         self._last_slow_poll: float = 0
         self._last_offset_poll: float = 0

--- a/custom_components/tado_hijack/helpers/tadov3/executor.py
+++ b/custom_components/tado_hijack/helpers/tadov3/executor.py
@@ -169,6 +169,16 @@ class TadoV3Executor(TadoExecutorBase):
                 },
             )
 
+        for zid, timetable_id in merged.get("timetables", {}).items():
+            if self._should_skip_zone(zid):  # [DUMMY_HOOK]
+                continue
+
+            await self._safe_execute(
+                f"timetable_{zid}",
+                self.client.set_active_timetable(zid, timetable_id),
+                context={"zone_id": zid, "timetable_id": timetable_id},
+            )
+
     async def _execute_zone_actions(self, merged: dict[str, Any]) -> None:
         """Execute overlays and resumes using v3 bulk endpoints."""
         zones = merged["zones"]

--- a/custom_components/tado_hijack/models.py
+++ b/custom_components/tado_hijack/models.py
@@ -61,6 +61,7 @@ class CommandType(StrEnum):
     SET_DAZZLE = "set_dazzle"
     SET_EARLY_START = "set_early_start"
     SET_OPEN_WINDOW = "set_open_window"
+    SET_TIMETABLE = "set_timetable"
     IDENTIFY = "identify"
 
 

--- a/custom_components/tado_hijack/translations/de.json
+++ b/custom_components/tado_hijack/translations/de.json
@@ -279,6 +279,9 @@
       },
       "identify_device": {
         "name": "Gerät identifizieren"
+      },
+      "refresh_timetable": {
+        "name": "Zeitplan aktualisieren"
       }
     },
     "number": {
@@ -333,6 +336,14 @@
           "on": "An",
           "off": "Aus",
           "auto": "Automatisch"
+        }
+      },
+      "timetable_type": {
+        "name": "Wochenplan-Modus",
+        "state": {
+          "one_day": "Mo-So (gleich jeden Tag)",
+          "three_day": "Mo-Fr / Sa / So",
+          "seven_day": "Pro Wochentag"
         }
       }
     },

--- a/custom_components/tado_hijack/translations/de.json
+++ b/custom_components/tado_hijack/translations/de.json
@@ -282,6 +282,9 @@
       },
       "refresh_timetable": {
         "name": "Zeitplan aktualisieren"
+      },
+      "refresh_all_timetables": {
+        "name": "Alle Zeitpläne aktualisieren"
       }
     },
     "number": {
@@ -340,6 +343,14 @@
       },
       "timetable_type": {
         "name": "Wochenplan-Modus",
+        "state": {
+          "one_day": "Mo-So (gleich jeden Tag)",
+          "three_day": "Mo-Fr / Sa / So",
+          "seven_day": "Pro Wochentag"
+        }
+      },
+      "timetable_type_all_zones": {
+        "name": "Zeitplantyp (alle Zonen)",
         "state": {
           "one_day": "Mo-So (gleich jeden Tag)",
           "three_day": "Mo-Fr / Sa / So",

--- a/custom_components/tado_hijack/translations/en.json
+++ b/custom_components/tado_hijack/translations/en.json
@@ -279,6 +279,9 @@
       },
       "identify_device": {
         "name": "Identify Device"
+      },
+      "refresh_timetable": {
+        "name": "Refresh timetable"
       }
     },
     "number": {
@@ -333,6 +336,14 @@
           "on": "On",
           "off": "Off",
           "auto": "Auto"
+        }
+      },
+      "timetable_type": {
+        "name": "Schedule Mode",
+        "state": {
+          "one_day": "Mon-Sun (same every day)",
+          "three_day": "Mon-Fri / Sat / Sun",
+          "seven_day": "Per day of the week"
         }
       }
     },

--- a/custom_components/tado_hijack/translations/en.json
+++ b/custom_components/tado_hijack/translations/en.json
@@ -282,6 +282,9 @@
       },
       "refresh_timetable": {
         "name": "Refresh timetable"
+      },
+      "refresh_all_timetables": {
+        "name": "Refresh all timetables"
       }
     },
     "number": {
@@ -340,6 +343,14 @@
       },
       "timetable_type": {
         "name": "Schedule Mode",
+        "state": {
+          "one_day": "Mon-Sun (same every day)",
+          "three_day": "Mon-Fri / Sat / Sun",
+          "seven_day": "Per day of the week"
+        }
+      },
+      "timetable_type_all_zones": {
+        "name": "Timetable type (all zones)",
         "state": {
           "one_day": "Mon-Sun (same every day)",
           "three_day": "Mon-Fri / Sat / Sun",


### PR DESCRIPTION
## What does this PR do?

Add timetable selector (one_day, three days or seven days) and resfresh buttons.
1poll per zone. No poll at start to avoid using lots of API requests

## Related Issue

Fixes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Affected Generation(s)

- [ ] V2 - GW Bridge
- [x] V3 Classic (HomeKit)
- [ ] Tado X (Matter)
- [ ] All / not generation-specific

## Testing

Work on V3

## Checklist

- [ ] Pre-commit passes (`ruff`, `mypy`, `hassfest`, `HACS`)
- [x] No debug logging left in
- [x] Tested on real hardware or described why not applicable
