### PR TITLE
fix: prevent runaway reset-poll loop on Tado X setups

### DIFF
--- a/custom_components/tado_hijack/helpers/poll_scheduler.py
+++ b/custom_components/tado_hijack/helpers/poll_scheduler.py
@@ -15,6 +15,11 @@ _LOGGER = get_redacted_logger(__name__)
 
 type AsyncCallback = Callable[[], Coroutine[Any, Any, None]]
 
+# Safety net for schedule_reset_poll: any delay shorter than this threshold
+# is treated as a stale/negative target and replaced with the fallback.
+_RESET_POLL_SAFETY_THRESHOLD_S: float = 300.0
+_RESET_POLL_SAFETY_FALLBACK_S: float = 3600.0
+
 
 class PollScheduler:
     """Manages deferred poll timers for the coordinator.
@@ -82,8 +87,13 @@ class PollScheduler:
         """Schedule a one-shot timer that fires *callback* after *delay_s* seconds."""
         if self._reset_poll_unsub:
             self._reset_poll_unsub.cancel()
+        # If delay is suspiciously small (stale/negative target), fall back to
+        # 1 hour to prevent a runaway 1-second loop that exhausts the Tado API
+        # quota and causes token invalidation. The primary fix is in
+        # get_initial_target(), this is a second line of defence.
+        safe_delay = delay_s if delay_s > _RESET_POLL_SAFETY_THRESHOLD_S else _RESET_POLL_SAFETY_FALLBACK_S
         self._reset_poll_unsub = self._hass.loop.call_later(
-            max(1.0, delay_s),
+            safe_delay,
             lambda: self._hass.async_create_task(callback()),
         )
 

--- a/custom_components/tado_hijack/helpers/reset_window_tracker.py
+++ b/custom_components/tado_hijack/helpers/reset_window_tracker.py
@@ -68,25 +68,33 @@ class ResetWindowTracker:
 
     def get_initial_target(self) -> datetime:
         """Get or create a static initial target for new setups."""
-        if self._initial_target is None:
-            berlin_tz = dt_util.get_time_zone("Europe/Berlin")
-            now_berlin = dt_util.now().astimezone(berlin_tz)
+        berlin_tz = dt_util.get_time_zone("Europe/Berlin")
+        now_berlin = dt_util.now().astimezone(berlin_tz)
 
-            target = now_berlin.replace(
-                hour=self._default_hour,
-                minute=self._default_minute,
-                second=0,
-                microsecond=0,
-            )
+        # Always compute a fresh candidate so the staleness check is based
+        # on the fully-advanced target, not the cached value. This avoids a
+        # perpetual-stale edge case where the cached datetime is in the past
+        # but a newly-computed one (before day-advancing) would also be past.
+        # A stale _initial_target loaded from storage causes a 1-second
+        # runaway loop: delay <= 0 → max(1.0, delay) → poll every second
+        # → API quota exhausted → token invalidated.
+        target = now_berlin.replace(
+            hour=self._default_hour,
+            minute=self._default_minute,
+            second=0,
+            microsecond=0,
+        )
 
-            if target <= now_berlin:
-                target += timedelta(days=1)
+        if target <= now_berlin:
+            target += timedelta(days=1)
 
-            if (target - now_berlin).total_seconds() < (
-                API_RESET_MIN_PLANNING_HOURS * 3600
-            ):
-                target += timedelta(days=1)
+        if (target - now_berlin).total_seconds() < (
+            API_RESET_MIN_PLANNING_HOURS * 3600
+        ):
+            target += timedelta(days=1)
 
+        # Only update the cache if missing or the stored value is now stale.
+        if self._initial_target is None or self._initial_target <= now_berlin:
             self._initial_target = target
 
         return self._initial_target


### PR DESCRIPTION
## What does this PR do?

Fixes a runaway 1-second reset-poll loop that exhausts the daily Tado API quota on Tado X setups and causes daily OAuth token invalidation (described in detail in #94).

`get_initial_target()` cached its computed datetime in `_initial_target` and returned it unconditionally on every subsequent call. After an HA restart the value reloaded from `.storage` is a datetime **in the past**, so:

```python
delay = (past_datetime - now).total_seconds()  # negative
max(1.0, delay)                                 # → 1.0 second
```

The reset poll fires every second → ~1000 API calls in minutes → 429 flood → Tado invalidates the token → HTTP 400 on next startup → manual reauth required. Cycle repeats every 1-2 days.

On Tado X this always triggers because `last_reset` is always `None`: `sync_from_headers()` is only reached after a fully successful `fetch_full_update()`, but the hops API raises `ClientResponseError` before headers are processed, so `record_reset()` is never called.

**Fix 1 — `reset_window_tracker.py` (root cause):**
`get_initial_target()` now checks if the cached value is in the past and recalculates when stale.

**Fix 2 — `poll_scheduler.py` (defence in depth):**
`schedule_reset_poll()` treats `delay_s <= 300` as suspicious and substitutes 3600 s, so a stale target can never produce a sub-minute loop even if a future regression reintroduces the issue.

## Related Issue

Fixes #94

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Affected Generation(s)

- [ ] V2 - GW Bridge
- [ ] V3 Classic (HomeKit)
- [x] Tado X (Matter)
- [ ] All / not generation-specific

## Testing

Reproduced on Tado X IB02 (Matter) with v5.4.0: runaway loop confirmed in HA logs (reset poll every second), 429 storm observed, token invalidated. After applying both fixes: HA restarts cleanly, no reset-poll loop in logs, integration stays authenticated across restarts.

## Checklist

- [x] Pre-commit passes (`ruff`, `mypy`, `hassfest`, `HACS`)
- [x] No debug logging left in
- [x] Tested on real hardware or described why not applicable