### PR TITLE
fix: check isinstance for device.manufacturer before calling .lower()

### DIFF
--- a/custom_components/tado_hijack/helpers/device_linker.py
+++ b/custom_components/tado_hijack/helpers/device_linker.py
@@ -37,6 +37,7 @@ def _build_device_cache(hass: HomeAssistant, force: bool = False) -> None:
     for device in registry.devices.values():
         if (
             device.manufacturer
+            and isinstance(device.manufacturer, str)
             and "tado" in device.manufacturer.lower()
             and device.serial_number
         ):
@@ -88,6 +89,7 @@ def get_climate_entity_id(hass: HomeAssistant, serial_no: str) -> str | None:
             for device in d_registry.devices.values()
             if (
                 device.manufacturer
+                and isinstance(device.manufacturer, str)
                 and "tado" in device.manufacturer.lower()
                 and device.serial_number == serial_no
             )


### PR DESCRIPTION
## Summary

Fix AttributeError when `device.manufacturer` is an `int` instead of `str`.

## Root Cause

`device.manufacturer.lower()` was called without checking if `manufacturer` is a string. Some Home Assistant device registries have `manufacturer` as an integer.

## Fix

Add `isinstance(device.manufacturer, str)` check before calling `.lower()`.

## Testing

Applied to two locations where `.lower()` was called on `device.manufacturer`:
- `_build_device_cache()`
- `get_climate_entity_id()`

Closes #102
