### PR TITLE
Initial Tado X Hot Water Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ It is designed to work **alongside** your local HomeKit (v3) or Matter (Tado X) 
 > - **Other integrations:** Support Tado X only via **full cloud** (no local control, 100% API dependent)
 > - **Tado Hijack:** Uses **Matter** for local temperature control + cloud API for advanced features (Schedules, QuickActions, etc.)
 >
-> We support **BOTH** Tado v3 Classic (HomeKit) **AND** Tado X (Matter) through a unified architecture. Note: Some features are v3-specific (Hot Water, AC, Early Start) due to hardware limitations.
+> We support **BOTH** Tado v3 Classic (HomeKit) **AND** Tado X (Matter) through a unified architecture. Note: Some features are v3-specific (AC, Early Start) due to hardware limitations.
 
 <br>
 
@@ -118,7 +118,7 @@ It is designed to work **alongside** your local HomeKit (v3) or Matter (Tado X) 
 | Feature Category              | V2 (GW) | v3 Classic | Tado X | Notes                        |
 | :---------------------------- | :-----: | :--------: | :----: | :--------------------------- |
 | **Temperature Control**       | ☁️ |     ✅     |   ✅   | All: Cloud mode available / V3: HomeKit / X: Matter |
-| **Hot Water**                 | ✅ |     ✅     |   ❌   | Cloud API + water_heater entity |
+| **Hot Water**                 | ✅ |     ✅     |   ✅   | Cloud API + water_heater entity. Tado X supports only `auto` and `off` toggle (no setpoint) |
 | **AC Pro (Fan/Swing)**        | ✅ |     ✅     |   ❌   | Cloud API + climate entity   |
 | **QuickActions (Bulk)**       | ✅ |     ✅     |   ✅   | boost/off/resume = 1 call    |
 | **set_mode_all (Bulk)**       | ✅ |     ✅     |   ❌   | v3=1 call, X=N calls         |
@@ -203,7 +203,7 @@ While other integrations waste your precious API quota for every tiny interactio
 
 ### Cloud Features (Non-HomeKit)
 
-- **🚿 Professional Hot Water Platform:** Native `water_heater` entity with standardized `auto`, `heat`, and `off` modes. Full Pre-Validation ensures you never send invalid configurations.
+- **🚿 Professional Hot Water Platform:** Native `water_heater` entity for both v3 Classic and Tado X. v3: `auto`, `heat`, and `off` modes with full temperature control. Tado X: `auto` and `off` toggle (no setpoint). Full Pre-Validation ensures you never send invalid configurations.
 - **❄️ AC Pro Features:** Precise Fan Speed and Swing (Horizontal/Vertical) selection.
 - **📅 Schedule Transparency:** View the target temperature of your active Smart Schedule directly via the `auto_target_temperature` attribute while in `auto` mode (available for Heating, AC and Hot Water).
 - **🕵️‍♂️ Expert-Level Error Capturing:** Captures the actual response body from Tado\'s API (e.g. _"temperature must not be null"_), giving precise feedback for troubleshooting.
@@ -603,7 +603,7 @@ Cloud-only features that HomeKit does not support.
 | :---------------------------------- | :------------ | :---------------------------------------------------------------------------------------------- |
 | `switch.schedule`                   | Switch        | **ON** = Smart Schedule, **OFF** = Manual. Simple way to resume schedule. **Supports heating and AC zones** (v3). |
 | `climate.ac_{room}`                 | Climate       | **v3 AC Only:** Full HVAC mode control (`cool`, `heat`, `dry`, `fan`, `auto`) with native slider. |
-| `water_heater.hot_water`            | WaterHeater   | **v3 Only:** Modes: `auto` (schedule), `heat` (manual), `off`.                                 |
+| `water_heater.hot_water`            | WaterHeater   | **v3:** `auto`/`heat`/`off` with temperature. **Tado X:** `auto`/`off` only (no setpoint).      |
 | `binary_sensor.hot_water_power`     | Binary Sensor | **v3 Only:** Boiler heating status.                                                             |
 | `binary_sensor.hot_water_overlay`   | Binary Sensor | **v3 Only:** Manual override active status.                                                     |
 | `binary_sensor.hot_water_connectivity` | Binary Sensor | **v3 Only:** Zone connectivity based on device connections.                                  |
@@ -677,7 +677,7 @@ For advanced automation, use these services. All manual control services feature
 | `tado_hijack.resume_all_schedules`  | Restore Smart Schedule across all zones.                                                                                     | **1 call** (bulk)    | **1 call** (bulk)    |
 | `tado_hijack.set_mode`              | Set mode, temperature, and termination. Supports `hvac_mode` (auto, heat, off) and `overlay` (manual, next_block, presence). | **1 call** (batched) | **1 call** (batched) |
 | `tado_hijack.set_mode_all_zones`    | Targets all HEATING and/or AC zones at once using `hvac_mode`.                                                               | **1 call** (bulk)    | **N calls** (per zone) |
-| `tado_hijack.set_water_heater_mode` | Set `operation_mode` and temperature for hot water (v3 only).                                                                | **1 call**           | N/A (no HW zones)    |
+| `tado_hijack.set_water_heater_mode` | Set `operation_mode` for hot water. v3: `auto`/`heat`/`off` + temperature. Tado X: `auto`/`off` only.                       | **1 call**           | **1 call**           |
 | `tado_hijack.add_meter_reading`     | Upload a meter reading (integer) to Tado Energy IQ (v3 only).                                                                | **1 call**           | N/A (unsupported)    |
 | `tado_hijack.manual_poll`           | Force immediate data refresh. Use `refresh_type` to control scope. Add `entity_id` for a targeted single-entity fetch (saves quota). | **1-N** (depends)    | **1-N** (depends)    |
 

--- a/custom_components/tado_hijack/coordinator.py
+++ b/custom_components/tado_hijack/coordinator.py
@@ -906,8 +906,8 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
         """Resume hot water schedule for Tado X (direct Hops API call)."""
         from .helpers.tadox.const import TADOX_HOT_WATER_ZONE_ID
 
-        self.optimistic.set_zone(
-            TADOX_HOT_WATER_ZONE_ID, overlay=False, power="ON", grace_period=10.0
+        self.optimistic.apply_zone_state(
+            TADOX_HOT_WATER_ZONE_ID, overlay=False, grace_period=10.0
         )
         self.async_update_listeners()
         try:
@@ -921,7 +921,7 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
         """Force Tado X hot water OFF (direct Hops API call)."""
         from .helpers.tadox.const import TADOX_HOT_WATER_ZONE_ID
 
-        self.optimistic.set_zone(
+        self.optimistic.apply_zone_state(
             TADOX_HOT_WATER_ZONE_ID, overlay=True, power="OFF", grace_period=10.0
         )
         self.async_update_listeners()

--- a/custom_components/tado_hijack/coordinator.py
+++ b/custom_components/tado_hijack/coordinator.py
@@ -873,6 +873,10 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
         ignore_global_config: bool = False,
     ) -> None:
         """Set hot water zone to auto mode (resume schedule)."""
+        if self.generation == GEN_X:
+            await self._async_set_hot_water_tadox_resume()
+            return
+
         self._execute_resume_command(zone_id, operation_mode="auto")
 
         if refresh_after or (self._refresh_after_resume and not ignore_global_config):
@@ -882,6 +886,10 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
         self, zone_id: int, refresh_after: bool = False
     ) -> None:
         """Set hot water zone to off (manual overlay)."""
+        if self.generation == GEN_X:
+            await self._async_set_hot_water_tadox_off()
+            return
+
         data = build_overlay_data(
             zone_id,
             self.zones_meta,
@@ -893,6 +901,36 @@ class TadoDataUpdateCoordinator(DataUpdateCoordinator[Any]):
 
         if refresh_after:
             self._schedule_queued_refresh()
+
+    async def _async_set_hot_water_tadox_resume(self) -> None:
+        """Resume hot water schedule for Tado X (direct Hops API call)."""
+        from .helpers.tadox.const import TADOX_HOT_WATER_ZONE_ID
+
+        self.optimistic.set_zone(
+            TADOX_HOT_WATER_ZONE_ID, overlay=False, power="ON", grace_period=10.0
+        )
+        self.async_update_listeners()
+        try:
+            await self.tadox_bridge.async_resume_hot_water_schedule()
+        except Exception as e:
+            _LOGGER.error("Failed to resume Tado X hot water schedule: %s", e)
+            self.optimistic.clear_zone(TADOX_HOT_WATER_ZONE_ID)
+        self._schedule_queued_refresh()
+
+    async def _async_set_hot_water_tadox_off(self) -> None:
+        """Force Tado X hot water OFF (direct Hops API call)."""
+        from .helpers.tadox.const import TADOX_HOT_WATER_ZONE_ID
+
+        self.optimistic.set_zone(
+            TADOX_HOT_WATER_ZONE_ID, overlay=True, power="OFF", grace_period=10.0
+        )
+        self.async_update_listeners()
+        try:
+            await self.tadox_bridge.async_set_hot_water_off()
+        except Exception as e:
+            _LOGGER.error("Failed to set Tado X hot water OFF: %s", e)
+            self.optimistic.clear_zone(TADOX_HOT_WATER_ZONE_ID)
+        self._schedule_queued_refresh()
 
     async def async_set_hot_water_heat(
         self, zone_id: int, temperature: float | None = None

--- a/custom_components/tado_hijack/helpers/tadox/const.py
+++ b/custom_components/tado_hijack/helpers/tadox/const.py
@@ -13,6 +13,10 @@ TADO_X_CLIENT_ID: Final = "1bb50063-6b0c-4d11-bd99-387f4a91cc46"
 # Hops API
 HOPS_BASE_URL: Final = "https://hops.tado.com"
 
+# Virtual zone ID used to store Tado X hot water state in zone_states.
+# Real Tado X rooms start at 1, so 0 is safe as a sentinel.
+TADOX_HOT_WATER_ZONE_ID: Final = 0
+
 # Grant Types
 GRANT_TYPE_DEVICE: Final = "urn:ietf:params:oauth:grant-type:device_code"
 GRANT_TYPE_REFRESH: Final = "refresh_token"

--- a/custom_components/tado_hijack/helpers/tadox/mapper.py
+++ b/custom_components/tado_hijack/helpers/tadox/mapper.py
@@ -24,6 +24,8 @@ class TadoXMapper:
         """Initialize the Tado X mapper."""
         self.bridge = bridge
         self._last_presence: str = "HOME"
+        # None = not yet probed; True = installed; False = not installed (skip future polls)
+        self._hot_water_available: bool | None = None
 
     async def async_fetch_unified_data(self) -> UnifiedTadoData:
         """Fetch all relevant Tado X data and return a UnifiedTadoData container."""
@@ -86,14 +88,24 @@ class TadoXMapper:
         return unified_data
 
     async def _fetch_hot_water_state_safe(self) -> TadoXHotWaterState | None:
-        """Fetch hot water state, returning None if not installed or on error."""
-        try:
-            return await self.bridge.async_get_hot_water_state()
-        except Exception as e:
-            _LOGGER.debug(
-                "Tado X hot water state fetch failed (may not be installed): %s", e
-            )
+        """Fetch hot water state, caching 'not installed' to avoid repeated 404 polls."""
+        if self._hot_water_available is False:
             return None
+
+        try:
+            result = await self.bridge.async_get_hot_water_state()
+        except Exception as e:
+            _LOGGER.debug("Tado X hot water state fetch failed (transient): %s", e)
+            return None  # Transient error — don't cache, retry next poll
+
+        if result is None:
+            if self._hot_water_available is None:
+                _LOGGER.debug("Tado X hot water programmer not detected (no hardware)")
+                self._hot_water_available = False
+            return None
+
+        self._hot_water_available = True
+        return result
 
     async def async_fetch_zones(self) -> dict[str, Any]:
         """Fetch Tado X room states (fast poll)."""

--- a/custom_components/tado_hijack/helpers/tadox/mapper.py
+++ b/custom_components/tado_hijack/helpers/tadox/mapper.py
@@ -75,8 +75,7 @@ class TadoXMapper:
             unified_data.zone_states[str(state.room_id)] = state
 
         # 3b. Map Hot Water State (virtual zone 0, if installed)
-        if (hw := await self._fetch_hot_water_state_safe()) is not None:
-            unified_data.zone_states[str(TADOX_HOT_WATER_ZONE_ID)] = hw
+        await self._augment_with_hot_water(unified_data.zone_states)
 
         # 4. Map Devices (Hardware Metadata)
         all_hops_devices = other_devices + [
@@ -107,6 +106,11 @@ class TadoXMapper:
         self._hot_water_available = True
         return result
 
+    async def _augment_with_hot_water(self, zones: dict[str, Any]) -> None:
+        """Add hot water state as virtual zone 0 if the programmer is installed."""
+        if (hw := await self._fetch_hot_water_state_safe()) is not None:
+            zones[str(TADOX_HOT_WATER_ZONE_ID)] = hw
+
     async def async_fetch_zones(self) -> dict[str, Any]:
         """Fetch Tado X room states (fast poll)."""
         try:
@@ -120,8 +124,7 @@ class TadoXMapper:
             )
             return {}
         result: dict[str, Any] = {str(state.room_id): state for state in room_states}
-        if (hw := await self._fetch_hot_water_state_safe()) is not None:
-            result[str(TADOX_HOT_WATER_ZONE_ID)] = hw
+        await self._augment_with_hot_water(result)
         return result
 
     async def async_fetch_metadata(self) -> tuple[dict[int, Any], dict[str, Any]]:

--- a/custom_components/tado_hijack/helpers/tadox/mapper.py
+++ b/custom_components/tado_hijack/helpers/tadox/mapper.py
@@ -6,8 +6,10 @@ from typing import Any
 
 from ...const import GEN_X
 from ...lib.tadox_api import TadoXApi
+from ...lib.tadox_models import TadoXHotWaterState
 from ..logging_utils import get_redacted_logger
 from ..models_unified import UnifiedTadoData
+from .const import TADOX_HOT_WATER_ZONE_ID
 
 _LOGGER = get_redacted_logger(__name__)
 
@@ -70,6 +72,10 @@ class TadoXMapper:
         for state in room_states:
             unified_data.zone_states[str(state.room_id)] = state
 
+        # 3b. Map Hot Water State (virtual zone 0, if installed)
+        if (hw := await self._fetch_hot_water_state_safe()) is not None:
+            unified_data.zone_states[str(TADOX_HOT_WATER_ZONE_ID)] = hw
+
         # 4. Map Devices (Hardware Metadata)
         all_hops_devices = other_devices + [
             dev for room in rooms for dev in room.devices
@@ -78,6 +84,16 @@ class TadoXMapper:
             unified_data.devices[dev.serial_no] = dev
 
         return unified_data
+
+    async def _fetch_hot_water_state_safe(self) -> TadoXHotWaterState | None:
+        """Fetch hot water state, returning None if not installed or on error."""
+        try:
+            return await self.bridge.async_get_hot_water_state()
+        except Exception as e:
+            _LOGGER.debug(
+                "Tado X hot water state fetch failed (may not be installed): %s", e
+            )
+            return None
 
     async def async_fetch_zones(self) -> dict[str, Any]:
         """Fetch Tado X room states (fast poll)."""
@@ -91,7 +107,10 @@ class TadoXMapper:
                 exc_info=True,
             )
             return {}
-        return {str(state.room_id): state for state in room_states}
+        result: dict[str, Any] = {str(state.room_id): state for state in room_states}
+        if (hw := await self._fetch_hot_water_state_safe()) is not None:
+            result[str(TADOX_HOT_WATER_ZONE_ID)] = hw
+        return result
 
     async def async_fetch_metadata(self) -> tuple[dict[int, Any], dict[str, Any]]:
         """Fetch Tado X metadata (slow poll): rooms, devices, and presence."""

--- a/custom_components/tado_hijack/lib/tadox_api.py
+++ b/custom_components/tado_hijack/lib/tadox_api.py
@@ -22,7 +22,11 @@ from aiohttp import ClientTimeout
 from ..helpers.logging_utils import get_redacted_logger
 from ..helpers.parsers import parse_ratelimit_headers
 from ..helpers.tadox.const import HOPS_BASE_URL
-from .tadox_models import HopsRoomsAndDevicesResponse, TadoXHotWaterState, TadoXZoneState
+from .tadox_models import (
+    HopsRoomsAndDevicesResponse,
+    TadoXHotWaterState,
+    TadoXZoneState,
+)
 
 if TYPE_CHECKING:
     from tadoasync import Tado
@@ -232,7 +236,7 @@ class TadoXApi:
         """Fetch current hot water programmer state. Returns None if not installed (404)."""
         try:
             data = await self._request("GET", "programmer/domesticHotWater/state")
-            return TadoXHotWaterState.model_validate(data)
+            return cast(TadoXHotWaterState, TadoXHotWaterState.model_validate(data))
         except Exception:
             return None
 

--- a/custom_components/tado_hijack/lib/tadox_api.py
+++ b/custom_components/tado_hijack/lib/tadox_api.py
@@ -233,12 +233,15 @@ class TadoXApi:
         return await self._request("POST", "quickActions/allOff")
 
     async def async_get_hot_water_state(self) -> TadoXHotWaterState | None:
-        """Fetch current hot water programmer state. Returns None if not installed (404)."""
-        try:
-            data = await self._request("GET", "programmer/domesticHotWater/state")
-            return cast(TadoXHotWaterState, TadoXHotWaterState.model_validate(data))
-        except Exception:
-            return None
+        """Fetch current hot water programmer state.
+
+        Returns None when the endpoint returns an empty response (404 = not installed).
+        Raises on network or unexpected errors so callers can distinguish transient failures.
+        """
+        data = await self._request("GET", "programmer/domesticHotWater/state")
+        if not data:
+            return None  # 404 → _request returns {} → not installed
+        return cast(TadoXHotWaterState, TadoXHotWaterState.model_validate(data))
 
     async def async_resume_hot_water_schedule(self) -> Any:
         """Resume hot water schedule (clear boost override)."""

--- a/custom_components/tado_hijack/lib/tadox_api.py
+++ b/custom_components/tado_hijack/lib/tadox_api.py
@@ -22,7 +22,7 @@ from aiohttp import ClientTimeout
 from ..helpers.logging_utils import get_redacted_logger
 from ..helpers.parsers import parse_ratelimit_headers
 from ..helpers.tadox.const import HOPS_BASE_URL
-from .tadox_models import HopsRoomsAndDevicesResponse, TadoXZoneState
+from .tadox_models import HopsRoomsAndDevicesResponse, TadoXHotWaterState, TadoXZoneState
 
 if TYPE_CHECKING:
     from tadoasync import Tado
@@ -227,6 +227,26 @@ class TadoXApi:
     async def async_turn_off_all_zones(self) -> Any:
         """Turn off all rooms (frost protection mode)."""
         return await self._request("POST", "quickActions/allOff")
+
+    async def async_get_hot_water_state(self) -> TadoXHotWaterState | None:
+        """Fetch current hot water programmer state. Returns None if not installed (404)."""
+        try:
+            data = await self._request("GET", "programmer/domesticHotWater/state")
+            return TadoXHotWaterState.model_validate(data)
+        except Exception:
+            return None
+
+    async def async_resume_hot_water_schedule(self) -> Any:
+        """Resume hot water schedule (clear boost override)."""
+        return await self._request("POST", "programmer/domesticHotWater/resumeSchedule")
+
+    async def async_set_hot_water_off(self) -> Any:
+        """Force hot water OFF via boost override."""
+        return await self._request(
+            "POST",
+            "programmer/domesticHotWater/boost",
+            json_data={"boost": "OFF"},
+        )
 
     async def async_set_open_window_detection(self, room_id: int, enabled: bool) -> Any:
         """Enable or disable open window detection."""

--- a/custom_components/tado_hijack/lib/tadox_models.py
+++ b/custom_components/tado_hijack/lib/tadox_models.py
@@ -227,3 +227,36 @@ class HopsRoomsAndDevicesResponse(BaseModel):
     rooms: list[HopsRoomSnapshot]
     other_devices: list[TadoXDevice] = Field(alias="otherDevices")
     home: HomePresence | None = None  # Presence information
+
+
+# --- Tado X Hot Water ---
+
+
+class _HotWaterSetting:
+    """Minimal duck-type of v3 zone setting for hot water compatibility."""
+
+    def __init__(self, power: str) -> None:
+        self.power = power
+
+
+class TadoXHotWaterState(BaseModel):
+    """State model for the Tado X domestic hot water programmer.
+
+    Maps the /programmer/domesticHotWater/state response and duck-types
+    the v3 zone state interface expected by water_heater.py.
+    """
+
+    state: str
+    next_state_change: str | None = Field(None, alias="nextStateChange")
+    setpoint: Any | None = None
+    setpoint_constraints: Any | None = Field(None, alias="setpointConstraints")
+
+    @property
+    def overlay_active(self) -> bool:
+        """True when hot water is manually overridden (not following schedule)."""
+        return not self.state.startswith("SCHEDULE_")
+
+    @property
+    def setting(self) -> _HotWaterSetting:
+        """Duck-type v3 setting so water_heater._get_actual_value() reads power correctly."""
+        return _HotWaterSetting(power="OFF" if self.overlay_active else "ON")

--- a/custom_components/tado_hijack/water_heater.py
+++ b/custom_components/tado_hijack/water_heater.py
@@ -286,6 +286,18 @@ class TadoHotWaterX(TadoHotWater):
             return {"next_state_change": nsc}
         return {}
 
+    def _get_actual_value(self) -> str:
+        """Return actual operation mode, restricted to Tado X hot water modes (auto/off)."""
+        state = self.coordinator.data.zone_states.get(str(self._zone_id))
+        if state is None:
+            return OPERATION_MODE_AUTO
+        # Any active overlay on Tado X hot water means manually forced OFF
+        return (
+            OPERATION_MODE_OFF
+            if getattr(state, "overlay_active", False)
+            else OPERATION_MODE_AUTO
+        )
+
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Temperature control not supported for Tado X hot water."""
 
@@ -295,3 +307,9 @@ class TadoHotWaterX(TadoHotWater):
             await self.tado_coordinator.async_set_hot_water_off(self._zone_id)
         elif operation_mode == OPERATION_MODE_AUTO:
             await self.tado_coordinator.async_set_hot_water_auto(self._zone_id)
+        else:
+            _LOGGER.warning(
+                "Tado X hot water: unsupported operation mode '%s' (supported: %s)",
+                operation_mode,
+                OPERATION_MODES_TADOX,
+            )

--- a/custom_components/tado_hijack/water_heater.py
+++ b/custom_components/tado_hijack/water_heater.py
@@ -18,6 +18,7 @@ from .const import (
     TEMP_STEP_HOT_WATER,
     ZONE_TYPE_HOT_WATER,
 )
+from .helpers.tadox.const import TADOX_HOT_WATER_ZONE_ID
 from .entity import TadoHotWaterZoneEntity, TadoOptimisticMixin, TadoStateMemoryMixin
 from .helpers.discovery import yield_zones
 from .helpers.logging_utils import get_redacted_logger
@@ -35,13 +36,19 @@ OPERATION_MODE_HEAT = "heat"
 OPERATION_MODE_OFF = "off"
 
 OPERATION_MODES = [OPERATION_MODE_AUTO, OPERATION_MODE_HEAT, OPERATION_MODE_OFF]
+OPERATION_MODES_TADOX = [OPERATION_MODE_AUTO, OPERATION_MODE_OFF]
 
 
 def _setup_water_heater_entities_tadox(
     coordinator: TadoDataUpdateCoordinator,
 ) -> list[TadoHotWater]:
     """Set up hot water entities for Tado X."""
-    return []  # [TADO_X] Not yet supported
+    if coordinator.data.zone_states.get(str(TADOX_HOT_WATER_ZONE_ID)) is None:
+        _LOGGER.debug(
+            "No Tado X hot water found (programmer/domesticHotWater/state unavailable)"
+        )
+        return []
+    return [TadoHotWaterX(coordinator, TADOX_HOT_WATER_ZONE_ID, "Hot Water")]
 
 
 def _setup_water_heater_entities_v3(
@@ -258,3 +265,33 @@ class TadoHotWater(
             temperature=rounded_temp,
             overlay_type="HOT_WATER",
         )
+
+
+class TadoHotWaterX(TadoHotWater):
+    """Tado X hot water — schedule (auto) or forced off only, no temperature control."""
+
+    _attr_operation_list = OPERATION_MODES_TADOX
+    _attr_supported_features = WaterHeaterEntityFeature.OPERATION_MODE
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Tado X hot water has no setpoint."""
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return next schedule change time if available."""
+        state = self.coordinator.data.zone_states.get(str(self._zone_id))
+        if state and (nsc := getattr(state, "next_state_change", None)):
+            return {"next_state_change": nsc}
+        return {}
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Temperature control not supported for Tado X hot water."""
+
+    async def async_set_operation_mode(self, operation_mode: str) -> None:
+        """Set new operation mode (auto or off)."""
+        if operation_mode == OPERATION_MODE_OFF:
+            await self.tado_coordinator.async_set_hot_water_off(self._zone_id)
+        elif operation_mode == OPERATION_MODE_AUTO:
+            await self.tado_coordinator.async_set_hot_water_auto(self._zone_id)

--- a/custom_components/tado_hijack/water_heater.py
+++ b/custom_components/tado_hijack/water_heater.py
@@ -18,11 +18,11 @@ from .const import (
     TEMP_STEP_HOT_WATER,
     ZONE_TYPE_HOT_WATER,
 )
-from .helpers.tadox.const import TADOX_HOT_WATER_ZONE_ID
 from .entity import TadoHotWaterZoneEntity, TadoOptimisticMixin, TadoStateMemoryMixin
 from .helpers.discovery import yield_zones
 from .helpers.logging_utils import get_redacted_logger
 from .helpers.parsers import parse_schedule_temperature
+from .helpers.tadox.const import TADOX_HOT_WATER_ZONE_ID
 
 if TYPE_CHECKING:
     from . import TadoConfigEntry


### PR DESCRIPTION
## What does this PR do?

**Disclaimer**: I used AI to write this code. I understand that's not everyone's cup of tea, but I have reviewed it myself and ensured it passes linting / code standards. The flow / plan is logical to me. If not acceptible, I hope the logging in #106 helps!

Adds basic auto/off hot water control for Tado X devices. It does not control the scheduling function - this could be done in a future PR perhaps.

## Related Issue

Fixes #106 

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Affected Generation(s)

- [ ] V2 - GW Bridge
- [ ] V3 Classic (HomeKit)
- [X] Tado X (Matter)
- [ ] All / not generation-specific

## Testing

Tested by installing on Home Assistant and toggling on/off hot water. Verified by checking in the app that the switch was made. Also verified on Tado X Gateway that the hot water light came on / off.

## Checklist

- [X] Pre-commit passes (`ruff`, `mypy`, `hassfest`, `HACS`)
- [X] No debug logging left in
- [X] Tested on real hardware or described why not applicable