### PR TITLE
Fix optimistic fan state for consecutive AC setting updates

### DIFF
--- a/custom_components/tado_hijack/helpers/optimistic_manager.py
+++ b/custom_components/tado_hijack/helpers/optimistic_manager.py
@@ -162,6 +162,8 @@ class OptimisticManager:
         vertical_swing: str | None = None,
         horizontal_swing: str | None = None,
         grace_period: float | None = None,
+        fan_speed: str | None = None,
+        fan_level: str | None = None,
     ) -> None:
         """Apply a comprehensive optimistic state to a zone (DRY Orchestrator)."""
         if not overlay:
@@ -201,6 +203,14 @@ class OptimisticManager:
         if horizontal_swing is not None:
             self.set_optimistic(
                 "zone", zone_id, "horizontal_swing", horizontal_swing, grace_period
+            )
+        if fan_speed is not None:
+            self.set_optimistic(
+                "zone", zone_id, "fan_speed", fan_speed, grace_period
+            )
+        if fan_level is not None:
+            self.set_optimistic(
+                "zone", zone_id, "fan_level", fan_level, grace_period
             )
 
     def set_away_temp(

--- a/custom_components/tado_hijack/helpers/tadov3/action_provider.py
+++ b/custom_components/tado_hijack/helpers/tadov3/action_provider.py
@@ -181,7 +181,7 @@ class TadoV3ActionProvider(TadoActionProvider):
         if mode_caps:
             temperature = self._build_ac_temperature(mode_caps, key, value, state)
             additional_fields |= self._build_ac_fan_settings(
-                mode_caps, key, value, state
+                mode_caps, key, value, state, zone_id,
             )
             additional_fields |= self._build_ac_swing_settings(
                 mode_caps, key, value, state, zone_id
@@ -208,6 +208,8 @@ class TadoV3ActionProvider(TadoActionProvider):
             overlay=True,
             power=POWER_ON,
             ac_mode=current_mode,
+            fan_speed=value if key == "fan_speed" else None,
+            fan_level=value if key == "fan_level" else None,
             vertical_swing=value if key == "vertical_swing" else None,
             horizontal_swing=value if key == "horizontal_swing" else None,
         )
@@ -236,7 +238,7 @@ class TadoV3ActionProvider(TadoActionProvider):
         return None
 
     def _build_ac_fan_settings(
-        self, mode_caps: Any, key: str, value: str, state: Any
+        self, mode_caps: Any, key: str, value: str, state: Any, zone_id: int,
     ) -> dict[str, str]:
         """Extract AC fan settings based on capabilities and input."""
         fields: dict[str, str] = {}
@@ -245,7 +247,14 @@ class TadoV3ActionProvider(TadoActionProvider):
             val = (
                 value
                 if key == "fan_speed"
-                else getattr(state.setting, "fan_speed", None)
+                else (
+                        self.coordinator.optimistic.get_optimistic(
+                            "zone",
+                            zone_id,
+                            "fan_speed",
+                        )
+                        or getattr(state.setting, "fan_speed", None)
+                )
             )
             if val:
                 val = val.upper()


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where consecutive AC setting changes (e.g. changing fan speed and then vertical swing) could reuse a stale cached fan state before Home Assistant had received the updated state from Tado.

This PR extends the optimistic state handling to fan_speed and fan_level, making it consistent with the existing optimistic handling for swing settings. As a result, consecutive commands use the latest user-requested values instead of outdated cached values.

## Related Issue

Fixes #

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Affected Generation(s)

- [ ] V2 - GW Bridge
- [X] V3 Classic (HomeKit)
- [ ] Tado X (Matter)
- [ ] All / not generation-specific

## Testing

Tested on a real air conditioner:

Steps:

1. Set fan speed to Auto.
2. Immediately change the vertical swing setting.
3. Before this fix, the second command reused the previous cached fan speed (e.g. 3) because the state had not yet been refreshed.
4. After this fix, the optimistic fan state is reused, so the fan remains in Auto while the swing setting changes correctly.

Repeated the test multiple times without reproducing the original issue.

## Checklist

- [X] Pre-commit passes (`ruff`, `mypy`, `hassfest`, `HACS`)
- [X] No debug logging left in
- [X] Tested on real hardware
