### PR TITLE
fix(translations): sync action schema and polish Czech

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -3,7 +3,10 @@ name: PR Tests
 on:
   pull_request:
     branches: ['dev', 'main']
-    paths: ['custom_components/tado_hijack/**']
+    paths:
+      - 'custom_components/tado_hijack/**'
+      - 'scripts/validate_translations.py'
+      - '.github/workflows/pr_tests.yml'
 
 jobs:
   # Job 1: Call the reusable linting workflow.
@@ -15,3 +18,17 @@ jobs:
   validation:
     name: "Run Validation"
     uses: ./.github/workflows/validate.yml
+
+  # Job 3: Ensure action and selector translations match services.yaml.
+  translation-validation:
+    name: "Validate Translations"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout the repository"
+        uses: actions/checkout@v5
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: "Validate translation schema"
+        run: python scripts/validate_translations.py

--- a/custom_components/tado_hijack/services.yaml
+++ b/custom_components/tado_hijack/services.yaml
@@ -1,12 +1,11 @@
 # Shared Field Definitions (DRY)
 manual_poll:
-  description: "Force immediate data refresh."
   fields:
     refresh_type:
-      description: "Which data to refresh. Use with entity_id for a targeted single-entity fetch (saves API quota). Without entity_id, all entities of that type are refreshed."
       default: "all"
       selector:
         select:
+          translation_key: refresh_type
           options:
             - "all"
             - "zone"
@@ -16,81 +15,69 @@ manual_poll:
             - "capabilities"
             - "presence"
     entity_id:
-      description: "Optional: restrict the refresh to a single entity (targeted fetch). Supported for: offsets, away, capabilities. Other types fall back to a full refresh."
       selector:
         entity:
           integration: tado_hijack
     config_entry:
-      description: "Optional: Target a specific Tado Home. If omitted and no entity_id is provided, applies to all Tado Homes."
       selector:
         config_entry:
           integration: tado_hijack
 
 resume_all_schedules:
-  description: "Restore Smart Schedule across all zones."
   fields:
     config_entry:
-      description: "Optional: Target a specific Tado Home. If omitted, applies to all Tado Homes."
       selector:
         config_entry:
           integration: tado_hijack
 
 turn_off_all_zones:
-  description: "Turn off all zones instantly."
   fields:
     config_entry:
-      description: "Optional: Target a specific Tado Home. If omitted, applies to all Tado Homes."
       selector:
         config_entry:
           integration: tado_hijack
 
 boost_all_zones:
-  description: "Boost all zones to 25°C."
   fields:
     config_entry:
-      description: "Optional: Target a specific Tado Home. If omitted, applies to all Tado Homes."
       selector:
         config_entry:
           integration: tado_hijack
 
 set_mode:
-  description: "Set a manual mode (overlay) with optional timer for Heating and AC zones."
   fields:
     entity_id:
-      description: "Any Tado zone entity (e.g. climate.living_room, switch.living_room_schedule). Device entities (e.g. TRV battery) will automatically resolve to their zone."
       required: true
       selector:
         entity:
           integration: tado_hijack
     hvac_mode:
-      description: "Operation mode: 'auto' (resume schedule), 'heat' (manual overlay), or 'off'."
       required: true
       default: "heat"
       selector:
         select:
+          translation_key: hvac_mode
           options:
             - "off"
             - "heat"
             - "auto"
     duration: &field_duration
-      description: "Duration in minutes after which the manual mode ends."
       selector:
         number:
           min: 1
           max: 1440
           unit_of_measurement: "min"
     overlay: &field_overlay
-      description: "Termination mode: 'manual' (indefinite), 'next_block' (return to schedule at next time block), or 'presence' (until presence change)."
       required: true
       default: "manual"
       selector:
         select:
+          translation_key: overlay_mode
           options:
             - "manual"
             - "next_block"
             - "presence"
     temperature:
-      description: "Target temperature (optional, 5-30°C)."
       default: 21.0
       selector:
         number:
@@ -99,38 +86,33 @@ set_mode:
           step: 0.1
           unit_of_measurement: "°C"
     refresh_after: &field_refresh_after
-      description: "Force immediate data refresh. Note: For permanent changes or 'Resume Schedule' (auto), this triggers immediately. For timed modes (duration), the refresh is deferred until the timer expires."
       required: true
       default: false
       selector:
         boolean: {}
 
 set_mode_all_zones:
-  description: "Set a manual overlay for all heating and/or AC zones at once."
   fields:
     config_entry:
-      description: "Optional: Target a specific Tado Home. If omitted, applies to all Tado Homes."
       selector:
         config_entry:
           integration: tado_hijack
     include_heating:
-      description: "Include all heating zones (Thermostats)."
       required: true
       default: true
       selector:
         boolean: {}
     include_ac:
-      description: "Include all air conditioning zones."
       required: true
       default: false
       selector:
         boolean: {}
     hvac_mode:
-      description: "Operation mode: 'auto' (resume schedule), 'heat' (manual overlay), or 'off'."
       required: true
       default: "heat"
       selector:
         select:
+          translation_key: hvac_mode
           options:
             - "off"
             - "heat"
@@ -138,7 +120,6 @@ set_mode_all_zones:
     duration: *field_duration
     overlay: *field_overlay
     temperature:
-      description: "Target temperature (will be automatically capped)."
       default: 21.0
       selector:
         number:
@@ -149,21 +130,19 @@ set_mode_all_zones:
     refresh_after: *field_refresh_after
 
 set_water_heater_mode:
-  description: "Set a manual mode (overlay) with optional timer for Water Heater zones."
   fields:
     entity_id:
-      description: "Any Tado Hijack water heater entity (e.g. water_heater.hot_water)."
       required: true
       selector:
         entity:
           domain: water_heater
           integration: tado_hijack
     operation_mode:
-      description: "Operation mode: 'auto' (resume schedule), 'heat' (on), or 'off'."
       required: true
       default: "heat"
       selector:
         select:
+          translation_key: water_heater_operation_mode
           options:
             - "off"
             - "heat"
@@ -171,7 +150,6 @@ set_water_heater_mode:
     duration: *field_duration
     overlay: *field_overlay
     temperature:
-      description: "Target temperature (30-65°C)."
       default: 50
       selector:
         number:
@@ -182,16 +160,13 @@ set_water_heater_mode:
     refresh_after: *field_refresh_after
 
 add_meter_reading:
-  description: "Upload a meter reading to Tado Energy IQ."
   fields:
     config_entry:
-      description: "Tado Hijack configuration entry."
       required: true
       selector:
         config_entry:
           integration: tado_hijack
     reading:
-      description: "Meter reading value (integer)."
       required: true
       selector:
         number:

--- a/custom_components/tado_hijack/translations/cs.json
+++ b/custom_components/tado_hijack/translations/cs.json
@@ -34,15 +34,15 @@
         "name": "Stav API",
         "state": {
           "connected": "Připojeno",
-          "throttled": "Omezeno (Throttled)",
-          "rate_limited": "Limit vyčerpán (Rate Limited)"
+          "throttled": "Dočasně omezeno",
+          "rate_limited": "Dosažen limit požadavků"
         }
       },
       "proxy_url": {
-        "name": "API Proxy URL"
+        "name": "Adresa proxy API"
       },
       "proxy_token": {
-        "name": "API Proxy Token"
+        "name": "Token proxy API"
       },
       "current_zone_interval": {
         "name": "Aktuální interval dotazování zón"
@@ -57,7 +57,7 @@
         "name": "Snížený interval dotazování"
       },
       "debounce_time": {
-        "name": "Čas seskupení (Debounce)"
+        "name": "Prodleva slučování požadavků"
       },
       "presence_poll_interval": {
         "name": "Interval dotazování přítomnosti"
@@ -117,7 +117,7 @@
         "name": "Práh omezení"
       },
       "jitter_percent": {
-        "name": "Procento odchylky (Jitter)"
+        "name": "Náhodné rozptýlení intervalů"
       },
       "reduced_polling_start": {
         "name": "Začátek omezeného dotazování"
@@ -148,7 +148,7 @@
         "state": {
           "schedule": "Podle plánu",
           "off": "Vypnuto",
-          "boost": "Zvýšený výkon (Boost)",
+          "boost": "Zvýšený výkon",
           "manual": "Manuálně"
         }
       },
@@ -157,7 +157,7 @@
         "state": {
           "schedule": "Podle plánu",
           "off": "Vypnuto",
-          "boost": "Zvýšený výkon (Boost)",
+          "boost": "Zvýšený výkon",
           "manual": "Manuálně",
           "mixed": "Smíšený"
         }
@@ -177,7 +177,7 @@
         "name": "Připojení Bridge ke cloudu"
       },
       "overlay": {
-        "name": "Manuální zásah (Overlay)"
+        "name": "Ruční změna"
       },
       "power": {
         "name": "Napájení"
@@ -199,7 +199,7 @@
         "name": "Omezené dotazování aktivní"
       },
       "call_jitter_enabled": {
-        "name": "Odchylka dotazů (Jitter) povolena"
+        "name": "Náhodné rozptýlení intervalů povoleno"
       },
       "disable_polling_when_throttled": {
         "name": "Zakázat dotazování při omezení"
@@ -272,7 +272,7 @@
         "name": "Vypnout všechny zóny"
       },
       "boost_all_zones": {
-        "name": "Zvýšit výkon všech zón (Boost)"
+        "name": "Zvýšit výkon všech zón"
       },
       "resume_schedule": {
         "name": "Obnovit plán"
@@ -353,11 +353,11 @@
   },
   "config": {
     "progress": {
-      "wait_for_device": "Pro ověření otevřete následující URL adresu a přihlaste se k Tado:\n\n{url}\n\nPokud se kód nezkopíroval automaticky, vložte následující kód pro autorizaci integrace:\n\n### {code}\n\nPokus o přihlášení vyprší za pět minut."
+      "wait_for_device": "Pro ověření otevřete následující odkaz a přihlaste se k Tado:\n\n{url}\n\nPokud se kód nezkopíroval automaticky, vložte následující kód pro autorizaci integrace:\n\n### {code}\n\nPokus o přihlášení vyprší za pět minut."
     },
     "abort": {
       "already_configured": "Účet je již nakonfigurován.",
-      "could_not_authenticate": "Nepodařilo se ověřit s Tado.",
+      "could_not_authenticate": "Nepodařilo se ověřit účet Tado.",
       "no_homes_returned": "Ověření selhalo: Tado API nevrátilo žádné 'domácnosti' spojené s vaším účtem. Otevřete oficiální aplikaci Tado a zkontrolujte, zda nemusíte přijmout nové podmínky nebo dokončit nastavení domácnosti. Pokud problém přetrvává, nahlaste to na GitHubu.",
       "no_homes": "S tímto Tado účtem nejsou spojeny žádné domácnosti.",
       "cannot_connect": "Připojení selhalo.",
@@ -369,7 +369,7 @@
       "user": {
         "title": "Propojit Tado Hijack",
         "data": {
-          "generation": "Tado hardwarová generace",
+          "generation": "Generace hardwaru Tado",
           "full_cloud_mode": "Plný cloudový režim",
           "fetch_extended_data": "Stáhnout rozšířená data"
         },
@@ -393,10 +393,10 @@
           "general_polling": {
             "name": "Obecné intervaly dotazování",
             "data": {
-              "scan_interval": "Interval dotazování stavu (Vteřiny)",
-              "presence_poll_interval": "Interval dotazování přítomnosti (Vteřiny)",
-              "slow_poll_interval": "Interval synchronizace hardwaru (Vteřiny)",
-              "offset_poll_interval": "Interval aktualizace teplotní odchylky (Vteřiny)"
+              "scan_interval": "Interval aktualizace zón (sekundy)",
+              "presence_poll_interval": "Interval aktualizace přítomnosti (sekundy)",
+              "slow_poll_interval": "Interval synchronizace hardwaru (sekundy)",
+              "offset_poll_interval": "Interval aktualizace teplotní odchylky (sekundy)"
             },
             "data_description": {
               "scan_interval": "Interval pro data místnosti (teplota, vlhkost, výkon topení). DŮLEŽITÉ: Dynamicky přepisováno 'Automatickou API kvótou', pokud je povolena; slouží jako záloha při vyčerpání vypočteného rozpočtu.",
@@ -406,21 +406,21 @@
             }
           },
           "api_quota": {
-            "name": "Auto API kvóta a bezpečnost",
+            "name": "Automatické řízení kvóty API a zabezpečení",
             "data": {
-              "auto_api_quota_percent": "Automatická API kvóta (%)",
+              "auto_api_quota_percent": "Automaticky využitá kvóta API (%)",
               "throttle_threshold": "Práh omezení (Bezpečnostní rezerva)",
               "quota_safety_reserve": "Bezpečnostní rezerva kvóty API",
-              "min_auto_quota_interval_s": "Minimální interval Auto kvóty",
+              "min_auto_quota_interval_s": "Minimální interval automatické kvóty",
               "disable_polling_when_throttled": "Zakázat dotazování při omezení",
               "refresh_after_resume": "Obnovit stav po zrušení manuální změny",
               "suppress_redundant_calls": "Potlačit nadbytečné dotazy",
               "suppress_redundant_buttons": "Potlačit nadbytečná tlačítka"
             },
             "data_description": {
-              "auto_api_quota_percent": "Využít X% VOLNÉ denní kvóty pro zjišťování stavu (0 = vypnuto). VOLNÉ = Limit - Rezerva na pozadí (Synch) - Externí aktivita (Automatizace, ruční použití). Hybridní strategie: Používá MAX(Denní rozpočet - Použito, Zbývající * X%) → Systém VŽDY pokračuje v dotazování i po překročení denního rozpočtu.",
-              "throttle_threshold": "Rezervovat N dotazů pro VŠECHNO mimo pravidelné dotazování Hijacku na pozadí (Automatizace, Skripty, Manuální použití aplikace). Dotazování se na této hranici zastaví, aby se vaše automatizace nikdy nezasekly. Doporučeno: 20.",
-              "quota_safety_reserve": "API dotazy vyhrazené pro okno samo-učícího se resetu. Systém se automaticky učí čas resetu a adaptivně rozděluje tuto rezervu k překlenutí cloudových výkyvů. 0 = vypnuto (nedoporučeno). Výchozí: 2.",
+              "auto_api_quota_percent": "Využít X % volné denní kvóty pro zjišťování stavu (0 = vypnuto). Volná kvóta = limit − rezerva na pozadí (synchronizace) − externí aktivita (automatizace, ruční použití). Hybridní strategie používá vyšší hodnotu z denního rozpočtu po odečtení již využitých požadavků a ze zbývající kvóty vynásobené X %. Systém proto pokračuje v dotazování i po překročení denního rozpočtu.",
+              "throttle_threshold": "Rezervuje N požadavků pro vše kromě pravidelného dotazování integrace na pozadí (automatizace, skripty a ruční použití aplikace). Po dosažení této hranice se pravidelné dotazování zastaví, aby zůstala kvóta pro ostatní požadavky. Doporučeno: 20.",
+              "quota_safety_reserve": "Počet požadavků API vyhrazených pro období samoučícího resetu. Systém se automaticky učí čas resetu a přizpůsobuje čerpání této rezervy výkyvům cloudové služby. Hodnota 0 funkci vypne (nedoporučuje se). Výchozí hodnota: 2.",
               "min_auto_quota_interval_s": "Minimální interval dotazování ve vteřinách (5-43200 = 12h max). Standardní API: minimum 5s. Proxy: vynuceno minimum 120s. Nižší = rychlejší aktualizace, ale vyšší využití API. Výchozí 20s.",
               "disable_polling_when_throttled": "Zcela zastavit pravidelné dotazování, když zbývající kvóta narazí na bezpečnostní rezervu.",
               "refresh_after_resume": "Automaticky stáhnout cílovou teplotu/stav po obnovení plánu (HVAC AUTO). Nutné, protože plány jsou spravovány na straně Tado cloudu. Stojí 1 API dotaz.",
@@ -434,7 +434,7 @@
               "reduced_polling_active": "Omezené dotazování aktivní",
               "reduced_polling_start": "Čas začátku okna",
               "reduced_polling_end": "Čas konce okna",
-              "reduced_polling_interval": "Ekonomický interval (Vteřiny)"
+              "reduced_polling_interval": "Ekonomický interval (sekundy)"
             },
             "data_description": {
               "reduced_polling_active": "Povolit profil váženého dotazování na základě času.",
@@ -459,13 +459,13 @@
             }
           },
           "advanced": {
-            "name": "API Proxy & Pokročilé",
+            "name": "Proxy API a pokročilá nastavení",
             "data": {
-              "api_proxy_url": "API Proxy URL (Volitelné)",
-              "proxy_token": "API Proxy Token (Volitelné)",
-              "call_jitter_enabled": "Povolit Call Jitter (Proxy)",
-              "jitter_percent": "Síla Jitteru (+/- %)",
-              "debounce_time": "Čas seskupení / Debounce (Vteřiny)",
+              "api_proxy_url": "Adresa proxy API (volitelné)",
+              "proxy_token": "Token proxy API (volitelné)",
+              "call_jitter_enabled": "Povolit náhodné rozptýlení požadavků",
+              "jitter_percent": "Rozsah náhodného rozptýlení (± %)",
+              "debounce_time": "Prodleva slučování požadavků (sekundy)",
               "log_level": "Úroveň logování",
               "log_version_prefix": "Zobrazit verzi v lozích"
             },
@@ -500,10 +500,10 @@
           "general_polling": {
             "name": "Obecné intervaly dotazování",
             "data": {
-              "scan_interval": "Interval dotazování stavu (Vteřiny)",
-              "presence_poll_interval": "Interval dotazování přítomnosti (Vteřiny)",
-              "slow_poll_interval": "Interval synchronizace hardwaru (Vteřiny)",
-              "offset_poll_interval": "Interval aktualizace teplotní odchylky (Vteřiny)"
+              "scan_interval": "Interval aktualizace zón (sekundy)",
+              "presence_poll_interval": "Interval aktualizace přítomnosti (sekundy)",
+              "slow_poll_interval": "Interval synchronizace hardwaru (sekundy)",
+              "offset_poll_interval": "Interval aktualizace teplotní odchylky (sekundy)"
             },
             "data_description": {
               "scan_interval": "Interval pro data místnosti (teplota, vlhkost, výkon topení). DŮLEŽITÉ: Dynamicky přepisováno 'Automatickou API kvótou', pokud je povolena; slouží jako záloha při vyčerpání vypočteného rozpočtu.",
@@ -513,21 +513,21 @@
             }
           },
           "api_quota": {
-            "name": "Auto API kvóta a bezpečnost",
+            "name": "Automatické řízení kvóty API a zabezpečení",
             "data": {
-              "auto_api_quota_percent": "Automatická API kvóta (%)",
+              "auto_api_quota_percent": "Automaticky využitá kvóta API (%)",
               "throttle_threshold": "Práh omezení (Bezpečnostní rezerva)",
               "quota_safety_reserve": "Bezpečnostní rezerva kvóty API",
-              "min_auto_quota_interval_s": "Minimální interval Auto kvóty",
+              "min_auto_quota_interval_s": "Minimální interval automatické kvóty",
               "disable_polling_when_throttled": "Zakázat dotazování při omezení",
               "refresh_after_resume": "Obnovit stav po zrušení manuální změny",
               "suppress_redundant_calls": "Potlačit nadbytečné dotazy",
               "suppress_redundant_buttons": "Potlačit nadbytečná tlačítka"
             },
             "data_description": {
-              "auto_api_quota_percent": "Využít X% VOLNÉ denní kvóty pro zjišťování stavu (0 = vypnuto). VOLNÉ = Limit - Rezerva na pozadí (Synch) - Externí aktivita (Automatizace, ruční použití). Hybridní strategie: Používá MAX(Denní rozpočet - Použito, Zbývající * X%) → Systém VŽDY pokračuje v dotazování i po překročení denního rozpočtu.",
-              "throttle_threshold": "Rezervovat N dotazů pro VŠECHNO mimo pravidelné dotazování Hijacku na pozadí (Automatizace, Skripty, Manuální použití aplikace). Dotazování se na této hranici zastaví, aby se vaše automatizace nikdy nezasekly. Doporučeno: 20.",
-              "quota_safety_reserve": "API dotazy vyhrazené pro okno samo-učícího se resetu. Systém se automaticky učí čas resetu a adaptivně rozděluje tuto rezervu k překlenutí cloudových výkyvů. 0 = vypnuto (nedoporučeno). Výchozí: 2.",
+              "auto_api_quota_percent": "Využít X % volné denní kvóty pro zjišťování stavu (0 = vypnuto). Volná kvóta = limit − rezerva na pozadí (synchronizace) − externí aktivita (automatizace, ruční použití). Hybridní strategie používá vyšší hodnotu z denního rozpočtu po odečtení již využitých požadavků a ze zbývající kvóty vynásobené X %. Systém proto pokračuje v dotazování i po překročení denního rozpočtu.",
+              "throttle_threshold": "Rezervuje N požadavků pro vše kromě pravidelného dotazování integrace na pozadí (automatizace, skripty a ruční použití aplikace). Po dosažení této hranice se pravidelné dotazování zastaví, aby zůstala kvóta pro ostatní požadavky. Doporučeno: 20.",
+              "quota_safety_reserve": "Počet požadavků API vyhrazených pro období samoučícího resetu. Systém se automaticky učí čas resetu a přizpůsobuje čerpání této rezervy výkyvům cloudové služby. Hodnota 0 funkci vypne (nedoporučuje se). Výchozí hodnota: 2.",
               "min_auto_quota_interval_s": "Minimální interval dotazování ve vteřinách (5-43200 = 12h max). Standardní API: minimum 5s. Proxy: vynuceno minimum 120s. Nižší = rychlejší aktualizace, ale vyšší využití API. Výchozí 20s.",
               "disable_polling_when_throttled": "Zcela zastavit pravidelné dotazování, když zbývající kvóta narazí na bezpečnostní rezervu.",
               "refresh_after_resume": "Automaticky stáhnout cílovou teplotu/stav po obnovení plánu (HVAC AUTO). Nutné, protože plány jsou spravovány na straně Tado cloudu. Stojí 1 API dotaz.",
@@ -541,7 +541,7 @@
               "reduced_polling_active": "Omezené dotazování aktivní",
               "reduced_polling_start": "Čas začátku okna",
               "reduced_polling_end": "Čas konce okna",
-              "reduced_polling_interval": "Ekonomický interval (Vteřiny)"
+              "reduced_polling_interval": "Ekonomický interval (sekundy)"
             },
             "data_description": {
               "reduced_polling_active": "Povolit profil váženého dotazování na základě času.",
@@ -566,13 +566,13 @@
             }
           },
           "advanced": {
-            "name": "API Proxy & Pokročilé",
+            "name": "Proxy API a pokročilá nastavení",
             "data": {
-              "api_proxy_url": "API Proxy URL (Volitelné)",
-              "proxy_token": "API Proxy Token (Volitelné)",
-              "call_jitter_enabled": "Povolit Call Jitter (Proxy)",
-              "jitter_percent": "Síla Jitteru (+/- %)",
-              "debounce_time": "Čas seskupení / Debounce (Vteřiny)",
+              "api_proxy_url": "Adresa proxy API (volitelné)",
+              "proxy_token": "Token proxy API (volitelné)",
+              "call_jitter_enabled": "Povolit náhodné rozptýlení požadavků",
+              "jitter_percent": "Rozsah náhodného rozptýlení (± %)",
+              "debounce_time": "Prodleva slučování požadavků (sekundy)",
               "log_level": "Úroveň logování",
               "log_version_prefix": "Zobrazit verzi v lozích"
             },
@@ -595,6 +595,10 @@
       "name": "Manuální načtení",
       "description": "Vynutí okamžitou aktualizaci z Tado API. S použitím entity_id provede cílené načtení pro jedinou entitu (šetří API kvótu).",
       "fields": {
+        "config_entry": {
+          "name": "Domácnost Tado (volitelné)",
+          "description": "Vybere konkrétní domácnost Tado. Bez výběru domácnosti a entity se aktualizují všechny nakonfigurované domácnosti."
+        },
         "refresh_type": {
           "name": "Typ obnovení",
           "description": "Která data se mají obnovit. Cílené typy (offsets, away, capabilities) podporují entity_id pro levnější stažení jediné entity."
@@ -607,69 +611,129 @@
     },
     "resume_all_schedules": {
       "name": "Obnovit všechny plány",
-      "description": "Zruší všechny manuální změny teploty ve všech zónách a vrátí se k Chytrému plánu (Smart Schedule)."
-    },
-    "turn_off_all_zones": {
-      "name": "Vypnout všechny zóny",
-      "description": "Vypne topení ve všech zónách."
-    },
-    "boost_all_zones": {
-      "name": "Zvýšit výkon všech zón (Boost)",
-      "description": "Zvýší topení ve všech zónách na 25 °C."
-    },
-    "set_timer": {
-      "name": "Nastavit časovač",
-      "description": "Nastaví manuální změnu teploty s časovým limitem nebo s automatickým návratem k plánu.",
+      "description": "Zruší všechny ruční změny teploty ve všech zónách a obnoví chytrý plán.",
       "fields": {
-        "entity_id": {
-          "name": "Entita",
-          "description": "Jakákoliv entita zóny z integrace Tado Hijack."
-        },
-        "duration": {
-          "name": "Trvání (Minuty)",
-          "description": "Doba trvání v minutách."
-        },
-        "overlay": {
-          "name": "Režim změny",
-          "description": "Režim ukončení: 'manual' (napořád), 'next_block' (návrat k plánu při dalším časovém bloku), nebo 'presence' (do změny přítomnosti)."
-        },
-        "power": {
-          "name": "Napájení",
-          "description": "Stav napájení (ON/OFF)."
-        },
-        "temperature": {
-          "name": "Teplota",
-          "description": "Cílová teplota (volitelné)."
+        "config_entry": {
+          "name": "Domácnost Tado (volitelné)",
+          "description": "Vybere konkrétní domácnost Tado. Bez výběru se akce provede ve všech nakonfigurovaných domácnostech."
         }
       }
     },
-    "set_timer_all_zones": {
-      "name": "Nastavit časovač pro všechny zóny",
-      "description": "Nastaví manuální změnu pro všechny topné a/nebo klimatizační zóny najednou.",
+    "turn_off_all_zones": {
+      "name": "Vypnout všechny zóny",
+      "description": "Vypne topení ve všech zónách.",
       "fields": {
+        "config_entry": {
+          "name": "Domácnost Tado (volitelné)",
+          "description": "Vybere konkrétní domácnost Tado. Bez výběru se akce provede ve všech nakonfigurovaných domácnostech."
+        }
+      }
+    },
+    "boost_all_zones": {
+      "name": "Zvýšit výkon všech zón",
+      "description": "Nastaví ve všech topných zónách cílovou teplotu na 25 °C.",
+      "fields": {
+        "config_entry": {
+          "name": "Domácnost Tado (volitelné)",
+          "description": "Vybere konkrétní domácnost Tado. Bez výběru se akce provede ve všech nakonfigurovaných domácnostech."
+        }
+      }
+    },
+    "set_mode": {
+      "name": "Nastavit režim zóny",
+      "description": "Nastaví ruční režim s volitelným časovačem pro topnou zónu nebo klimatizaci.",
+      "fields": {
+        "entity_id": {
+          "name": "Entita",
+          "description": "Topná zóna nebo klimatizace z integrace Tado Hijack."
+        },
+        "hvac_mode": {
+          "name": "Režim vytápění nebo chlazení",
+          "description": "Požadovaný režim zóny."
+        },
+        "duration": {
+          "name": "Doba trvání (minuty)",
+          "description": "Doba trvání časovače. Použije se pouze pro ruční režim."
+        },
+        "overlay": {
+          "name": "Ukončení ruční změny",
+          "description": "Určuje, kdy se zóna vrátí k plánu."
+        },
+        "temperature": {
+          "name": "Cílová teplota",
+          "description": "Cílová teplota v °C. Pro režim vypnuto není potřeba."
+        },
+        "refresh_after": {
+          "name": "Aktualizovat po změně",
+          "description": "Po provedení akce ihned načte aktuální stav z Tado API."
+        }
+      }
+    },
+    "set_mode_all_zones": {
+      "name": "Nastavit režim všech zón",
+      "description": "Nastaví stejný režim ve všech vybraných topných a klimatizačních zónách.",
+      "fields": {
+        "config_entry": {
+          "name": "Domácnost Tado (volitelné)",
+          "description": "Vybere konkrétní domácnost Tado. Bez výběru se akce provede ve všech nakonfigurovaných domácnostech."
+        },
         "include_heating": {
           "name": "Zahrnout topení",
           "description": "Zahrne všechny topné zóny."
         },
         "include_ac": {
-          "name": "Zahrnout AC",
-          "description": "Zahrne všechny zóny klimatizace."
+          "name": "Zahrnout klimatizaci",
+          "description": "Zahrne všechny klimatizační zóny."
+        },
+        "hvac_mode": {
+          "name": "Režim vytápění nebo chlazení",
+          "description": "Požadovaný režim všech vybraných zón."
         },
         "duration": {
-          "name": "Trvání (Minuty)",
-          "description": "Doba trvání v minutách."
+          "name": "Doba trvání (minuty)",
+          "description": "Doba trvání časovače. Použije se pouze pro ruční režim."
         },
         "overlay": {
-          "name": "Režim změny",
-          "description": "Režim ukončení: 'manual' (napořád), 'timer' (s určitou dobou trvání), 'next_block' (návrat k plánu při dalším časovém bloku), nebo 'presence' (do změny přítomnosti)."
-        },
-        "power": {
-          "name": "Napájení",
-          "description": "Stav napájení (ON/OFF)."
+          "name": "Ukončení ruční změny",
+          "description": "Určuje, kdy se zóny vrátí k plánu."
         },
         "temperature": {
-          "name": "Teplota",
-          "description": "Cílová teplota (bude omezena na základě typu zóny)."
+          "name": "Cílová teplota",
+          "description": "Cílová teplota v °C. Pro režim vypnuto není potřeba."
+        },
+        "refresh_after": {
+          "name": "Aktualizovat po změně",
+          "description": "Po provedení akce ihned načte aktuální stav z Tado API."
+        }
+      }
+    },
+    "set_water_heater_mode": {
+      "name": "Nastavit režim ohřevu vody",
+      "description": "Nastaví režim ohřevu vody s volitelným časovačem a cílovou teplotou.",
+      "fields": {
+        "entity_id": {
+          "name": "Ohřev vody",
+          "description": "Entita ohřevu vody z integrace Tado Hijack."
+        },
+        "operation_mode": {
+          "name": "Provozní režim",
+          "description": "Požadovaný režim ohřevu vody."
+        },
+        "duration": {
+          "name": "Doba trvání (minuty)",
+          "description": "Doba trvání časovače. Použije se pouze pro ruční režim."
+        },
+        "overlay": {
+          "name": "Ukončení ruční změny",
+          "description": "Určuje, kdy se ohřev vody vrátí k plánu."
+        },
+        "temperature": {
+          "name": "Cílová teplota",
+          "description": "Cílová teplota vody v °C, pokud ji zařízení podporuje."
+        },
+        "refresh_after": {
+          "name": "Aktualizovat po změně",
+          "description": "Po provedení akce ihned načte aktuální stav z Tado API."
         }
       }
     },
@@ -678,7 +742,7 @@
       "description": "Nahraje hodnotu odečtu na měřiči do Tado Energy IQ.",
       "fields": {
         "config_entry": {
-          "name": "Config Entry",
+          "name": "Konfigurační záznam",
           "description": "Konfigurační záznam Tado Hijack, ke kterému se má odečet přidat."
         },
         "reading": {
@@ -689,6 +753,38 @@
     }
   },
   "selector": {
+    "refresh_type": {
+      "options": {
+        "all": "Všechna data",
+        "zone": "Zóna",
+        "metadata": "Metadata",
+        "offsets": "Teplotní odchylky",
+        "away": "Teploty mimo domov",
+        "capabilities": "Možnosti zařízení",
+        "presence": "Přítomnost"
+      }
+    },
+    "hvac_mode": {
+      "options": {
+        "off": "Vypnuto",
+        "heat": "Vytápění nebo chlazení",
+        "auto": "Podle plánu"
+      }
+    },
+    "overlay_mode": {
+      "options": {
+        "manual": "Trvale",
+        "next_block": "Do dalšího časového bloku",
+        "presence": "Do změny přítomnosti"
+      }
+    },
+    "water_heater_operation_mode": {
+      "options": {
+        "off": "Vypnuto",
+        "heat": "Zapnuto",
+        "auto": "Podle plánu"
+      }
+    },
     "generation": {
       "options": {
         "classic": "Tado V2/V3 (Classic API)",

--- a/custom_components/tado_hijack/translations/de.json
+++ b/custom_components/tado_hijack/translations/de.json
@@ -602,51 +602,81 @@
         "entity_id": {
           "name": "Entity (optional)",
           "description": "Schränkt den Abruf auf eine einzelne Entity ein. Unterstützt für: offsets, away, capabilities. Andere Typen fallen auf einen vollständigen Refresh zurück."
+        },
+        "config_entry": {
+          "name": "Tado-Zuhause (optional)",
+          "description": "Wählt ein bestimmtes Tado-Zuhause aus. Ohne Auswahl und ohne Entität werden alle konfigurierten Zuhause aktualisiert."
         }
       }
     },
     "resume_all_schedules": {
       "name": "Zeitpläne fortsetzen",
-      "description": "Entfernt alle manuellen Änderungen in allen Zonen und kehrt zum Smart Schedule zurück."
-    },
-    "turn_off_all_zones": {
-      "name": "Alle Zonen ausschalten",
-      "description": "Schaltet die Heizung in allen Zonen aus."
-    },
-    "boost_all_zones": {
-      "name": "Alle Zonen aufheizen",
-      "description": "Heizt alle Zonen auf 25°C auf."
-    },
-    "set_timer": {
-      "name": "Timer setzen",
-      "description": "Setzt ein manuelles Overlay mit Timer, oder kehrt automatisch zum Zeitplan zurück.",
+      "description": "Entfernt alle manuellen Änderungen in allen Zonen und kehrt zum Smart Schedule zurück.",
       "fields": {
-        "entity_id": {
-          "name": "Entität",
-          "description": "Beliebige Zonen-Entität von Tado Hijack."
-        },
-        "duration": {
-          "name": "Dauer (Minuten)",
-          "description": "Dauer in Minuten."
-        },
-        "overlay": {
-          "name": "Overlay-Modus",
-          "description": "Beendigungsmodus: 'manual' (unbegrenzt), 'next_block' (Rückkehr zum nächsten Zeitblock) oder 'presence' (bis Anwesenheitsänderung)."
-        },
-        "power": {
-          "name": "Power",
-          "description": "Power-Status (ON/OFF)."
-        },
-        "temperature": {
-          "name": "Temperatur",
-          "description": "Zieltemperatur (optional)."
+        "config_entry": {
+          "name": "Tado-Zuhause (optional)",
+          "description": "Wählt ein bestimmtes Tado-Zuhause aus. Ohne Auswahl gilt die Aktion für alle konfigurierten Zuhause."
         }
       }
     },
-    "set_timer_all_zones": {
-      "name": "Timer für alle Zonen setzen",
-      "description": "Setzt ein manuelles Overlay für alle Heizungs- und/oder Klimazonen gleichzeitig.",
+    "turn_off_all_zones": {
+      "name": "Alle Zonen ausschalten",
+      "description": "Schaltet die Heizung in allen Zonen aus.",
       "fields": {
+        "config_entry": {
+          "name": "Tado-Zuhause (optional)",
+          "description": "Wählt ein bestimmtes Tado-Zuhause aus. Ohne Auswahl gilt die Aktion für alle konfigurierten Zuhause."
+        }
+      }
+    },
+    "boost_all_zones": {
+      "name": "Alle Zonen aufheizen",
+      "description": "Heizt alle Zonen auf 25°C auf.",
+      "fields": {
+        "config_entry": {
+          "name": "Tado-Zuhause (optional)",
+          "description": "Wählt ein bestimmtes Tado-Zuhause aus. Ohne Auswahl gilt die Aktion für alle konfigurierten Zuhause."
+        }
+      }
+    },
+    "set_mode": {
+      "name": "Zonenmodus einstellen",
+      "description": "Stellt einen manuellen Modus mit optionalem Timer für eine Heiz- oder Klimazone ein.",
+      "fields": {
+        "entity_id": {
+          "name": "Zonen-Entität",
+          "description": "Eine beliebige Zonen-Entität von Tado Hijack. Geräte-Entitäten werden automatisch ihrer Zone zugeordnet."
+        },
+        "hvac_mode": {
+          "name": "Betriebsmodus",
+          "description": "Setzt den Zeitplan fort, startet einen manuellen Heiz- oder Kühlmodus oder schaltet die Zone aus."
+        },
+        "duration": {
+          "name": "Dauer",
+          "description": "Dauer in Minuten, nach der der manuelle Modus endet."
+        },
+        "overlay": {
+          "name": "Endmodus",
+          "description": "Legt fest, ob die manuelle Änderung dauerhaft gilt, beim nächsten Zeitblock oder bei einer Anwesenheitsänderung endet."
+        },
+        "temperature": {
+          "name": "Zieltemperatur",
+          "description": "Optionale Zieltemperatur von 5 bis 30°C."
+        },
+        "refresh_after": {
+          "name": "Status nach Abschluss aktualisieren",
+          "description": "Aktualisiert sofort bei dauerhaften Änderungen und Zeitplanfortsetzung oder nach Ablauf eines zeitgesteuerten Modus."
+        }
+      }
+    },
+    "set_mode_all_zones": {
+      "name": "Modus für alle Zonen einstellen",
+      "description": "Stellt einen manuellen Modus für alle Heiz- und/oder Klimazonen gleichzeitig ein.",
+      "fields": {
+        "config_entry": {
+          "name": "Tado-Zuhause (optional)",
+          "description": "Wählt ein bestimmtes Tado-Zuhause aus. Ohne Auswahl gilt die Aktion für alle konfigurierten Zuhause."
+        },
         "include_heating": {
           "name": "Heizung einbeziehen",
           "description": "Bezieht alle Heizungszonen (Thermostate) mit ein."
@@ -655,21 +685,55 @@
           "name": "Klima einbeziehen",
           "description": "Bezieht alle Klimazonen mit ein."
         },
+        "hvac_mode": {
+          "name": "Betriebsmodus",
+          "description": "Setzt den Zeitplan fort, startet einen manuellen Heiz- oder Kühlmodus oder schaltet die Zonen aus."
+        },
         "duration": {
-          "name": "Dauer (Minuten)",
-          "description": "Dauer in Minuten."
+          "name": "Dauer",
+          "description": "Dauer in Minuten, nach der der manuelle Modus endet."
         },
         "overlay": {
-          "name": "Overlay-Modus",
-          "description": "Beendigungsmodus: 'manual' (unbegrenzt), 'next_block' (Rückkehr zum nächsten Zeitblock) oder 'presence' (bis Anwesenheitsänderung)."
-        },
-        "power": {
-          "name": "Power",
-          "description": "Power-Status (ON/OFF)."
+          "name": "Endmodus",
+          "description": "Legt fest, ob die manuelle Änderung dauerhaft gilt, beim nächsten Zeitblock oder bei einer Anwesenheitsänderung endet."
         },
         "temperature": {
-          "name": "Temperatur",
+          "name": "Zieltemperatur",
           "description": "Zieltemperatur (wird je nach Zonentyp automatisch begrenzt)."
+        },
+        "refresh_after": {
+          "name": "Status nach Abschluss aktualisieren",
+          "description": "Aktualisiert sofort bei dauerhaften Änderungen und Zeitplanfortsetzung oder nach Ablauf eines zeitgesteuerten Modus."
+        }
+      }
+    },
+    "set_water_heater_mode": {
+      "name": "Warmwassermodus einstellen",
+      "description": "Stellt einen manuellen Warmwassermodus mit optionalem Timer ein.",
+      "fields": {
+        "entity_id": {
+          "name": "Warmwasser-Entität",
+          "description": "Eine Warmwasser-Entität von Tado Hijack."
+        },
+        "operation_mode": {
+          "name": "Betriebsmodus",
+          "description": "Setzt den Zeitplan fort oder schaltet das Warmwasser ein oder aus."
+        },
+        "duration": {
+          "name": "Dauer",
+          "description": "Dauer in Minuten, nach der der manuelle Modus endet."
+        },
+        "overlay": {
+          "name": "Endmodus",
+          "description": "Legt fest, ob die manuelle Änderung dauerhaft gilt, beim nächsten Zeitblock oder bei einer Anwesenheitsänderung endet."
+        },
+        "temperature": {
+          "name": "Zieltemperatur",
+          "description": "Optionale Warmwasser-Zieltemperatur von 30 bis 65°C."
+        },
+        "refresh_after": {
+          "name": "Status nach Abschluss aktualisieren",
+          "description": "Aktualisiert sofort bei dauerhaften Änderungen und Zeitplanfortsetzung oder nach Ablauf eines zeitgesteuerten Modus."
         }
       }
     },
@@ -693,6 +757,38 @@
       "options": {
         "classic": "Tado V2/V3 (Classic API)",
         "x": "Tado X (Matter Bridge)"
+      }
+    },
+    "refresh_type": {
+      "options": {
+        "all": "Alle Daten",
+        "zone": "Zone",
+        "metadata": "Metadaten",
+        "offsets": "Temperaturoffsets",
+        "away": "Abwesenheitstemperaturen",
+        "capabilities": "Gerätefunktionen",
+        "presence": "Anwesenheit"
+      }
+    },
+    "hvac_mode": {
+      "options": {
+        "off": "Aus",
+        "heat": "Heizen oder Kühlen",
+        "auto": "Nach Zeitplan"
+      }
+    },
+    "overlay_mode": {
+      "options": {
+        "manual": "Dauerhaft",
+        "next_block": "Bis zum nächsten Zeitblock",
+        "presence": "Bis zur Anwesenheitsänderung"
+      }
+    },
+    "water_heater_operation_mode": {
+      "options": {
+        "off": "Aus",
+        "heat": "Ein",
+        "auto": "Nach Zeitplan"
       }
     }
   }

--- a/custom_components/tado_hijack/translations/en.json
+++ b/custom_components/tado_hijack/translations/en.json
@@ -602,51 +602,81 @@
         "entity_id": {
           "name": "Entity (optional)",
           "description": "Restrict the refresh to a single entity. Supported for: offsets, away, capabilities. Other types fall back to a full refresh."
+        },
+        "config_entry": {
+          "name": "Tado home (optional)",
+          "description": "Target a specific Tado home. If omitted and no entity is selected, all configured homes are refreshed."
         }
       }
     },
     "resume_all_schedules": {
       "name": "Resume All Schedules",
-      "description": "Remove all manual overlays in all zones and return to Smart Schedule."
-    },
-    "turn_off_all_zones": {
-      "name": "Turn Off All Zones",
-      "description": "Turn off heating in all zones."
-    },
-    "boost_all_zones": {
-      "name": "Boost All Zones",
-      "description": "Boost heating in all zones to 25°C."
-    },
-    "set_timer": {
-      "name": "Set Timer",
-      "description": "Set a manual overlay with timer duration or auto-return to schedule.",
+      "description": "Remove all manual overlays in all zones and return to Smart Schedule.",
       "fields": {
-        "entity_id": {
-          "name": "Entity",
-          "description": "Any zone entity from Tado Hijack."
-        },
-        "duration": {
-          "name": "Duration (Minutes)",
-          "description": "Duration in minutes."
-        },
-        "overlay": {
-          "name": "Overlay Mode",
-          "description": "Termination mode: 'manual' (indefinite), 'next_block' (return to next schedule block), or 'presence' (until presence change)."
-        },
-        "power": {
-          "name": "Power",
-          "description": "Power state (ON/OFF)."
-        },
-        "temperature": {
-          "name": "Temperature",
-          "description": "Target temperature (optional)."
+        "config_entry": {
+          "name": "Tado home (optional)",
+          "description": "Target a specific Tado home. If omitted, the action applies to all configured homes."
         }
       }
     },
-    "set_timer_all_zones": {
-      "name": "Set Timer for All Zones",
-      "description": "Set a manual overlay for all heating and/or AC zones at once.",
+    "turn_off_all_zones": {
+      "name": "Turn Off All Zones",
+      "description": "Turn off heating in all zones.",
       "fields": {
+        "config_entry": {
+          "name": "Tado home (optional)",
+          "description": "Target a specific Tado home. If omitted, the action applies to all configured homes."
+        }
+      }
+    },
+    "boost_all_zones": {
+      "name": "Boost All Zones",
+      "description": "Boost heating in all zones to 25°C.",
+      "fields": {
+        "config_entry": {
+          "name": "Tado home (optional)",
+          "description": "Target a specific Tado home. If omitted, the action applies to all configured homes."
+        }
+      }
+    },
+    "set_mode": {
+      "name": "Set zone mode",
+      "description": "Set a manual mode with an optional timer for a heating or air-conditioning zone.",
+      "fields": {
+        "entity_id": {
+          "name": "Zone entity",
+          "description": "Any Tado Hijack zone entity. Device entities are resolved to their zone automatically."
+        },
+        "hvac_mode": {
+          "name": "Operation mode",
+          "description": "Resume the schedule, start a manual heating or cooling mode, or turn the zone off."
+        },
+        "duration": {
+          "name": "Duration",
+          "description": "Duration in minutes after which the manual mode ends."
+        },
+        "overlay": {
+          "name": "End mode",
+          "description": "Choose whether the manual change is permanent, ends at the next schedule block, or ends when presence changes."
+        },
+        "temperature": {
+          "name": "Target temperature",
+          "description": "Optional target temperature from 5 to 30°C."
+        },
+        "refresh_after": {
+          "name": "Refresh after completion",
+          "description": "Refresh immediately for permanent changes and schedule resume, or after a timed mode expires."
+        }
+      }
+    },
+    "set_mode_all_zones": {
+      "name": "Set mode for all zones",
+      "description": "Set a manual mode for all heating and/or air-conditioning zones at once.",
+      "fields": {
+        "config_entry": {
+          "name": "Tado home (optional)",
+          "description": "Target a specific Tado home. If omitted, the action applies to all configured homes."
+        },
         "include_heating": {
           "name": "Include Heating",
           "description": "Include all heating zones."
@@ -655,21 +685,55 @@
           "name": "Include AC",
           "description": "Include all air conditioning zones."
         },
+        "hvac_mode": {
+          "name": "Operation mode",
+          "description": "Resume the schedule, start a manual heating or cooling mode, or turn the zones off."
+        },
         "duration": {
-          "name": "Duration (Minutes)",
-          "description": "Duration in minutes."
+          "name": "Duration",
+          "description": "Duration in minutes after which the manual mode ends."
         },
         "overlay": {
-          "name": "Overlay Mode",
-          "description": "Termination mode: 'manual' (indefinite), 'timer' (with duration), 'next_block' (return to schedule at next time block), or 'presence' (until presence change)."
-        },
-        "power": {
-          "name": "Power",
-          "description": "Power state (ON/OFF)."
+          "name": "End mode",
+          "description": "Choose whether the manual change is permanent, ends at the next schedule block, or ends when presence changes."
         },
         "temperature": {
-          "name": "Temperature",
-          "description": "Target temperature (will be capped based on zone type)."
+          "name": "Target temperature",
+          "description": "Target temperature, automatically limited according to each zone type."
+        },
+        "refresh_after": {
+          "name": "Refresh after completion",
+          "description": "Refresh immediately for permanent changes and schedule resume, or after a timed mode expires."
+        }
+      }
+    },
+    "set_water_heater_mode": {
+      "name": "Set hot water mode",
+      "description": "Set a manual hot water mode with an optional timer.",
+      "fields": {
+        "entity_id": {
+          "name": "Water heater entity",
+          "description": "A Tado Hijack water heater entity."
+        },
+        "operation_mode": {
+          "name": "Operation mode",
+          "description": "Resume the schedule, turn hot water on, or turn it off."
+        },
+        "duration": {
+          "name": "Duration",
+          "description": "Duration in minutes after which the manual mode ends."
+        },
+        "overlay": {
+          "name": "End mode",
+          "description": "Choose whether the manual change is permanent, ends at the next schedule block, or ends when presence changes."
+        },
+        "temperature": {
+          "name": "Target temperature",
+          "description": "Optional hot water target temperature from 30 to 65°C."
+        },
+        "refresh_after": {
+          "name": "Refresh after completion",
+          "description": "Refresh immediately for permanent changes and schedule resume, or after a timed mode expires."
         }
       }
     },
@@ -693,6 +757,38 @@
       "options": {
         "classic": "Tado V2/V3 (Classic API)",
         "x": "Tado X (Matter Bridge)"
+      }
+    },
+    "refresh_type": {
+      "options": {
+        "all": "All data",
+        "zone": "Zone",
+        "metadata": "Metadata",
+        "offsets": "Temperature offsets",
+        "away": "Away temperatures",
+        "capabilities": "Device capabilities",
+        "presence": "Presence"
+      }
+    },
+    "hvac_mode": {
+      "options": {
+        "off": "Off",
+        "heat": "Heating or cooling",
+        "auto": "Follow schedule"
+      }
+    },
+    "overlay_mode": {
+      "options": {
+        "manual": "Permanent",
+        "next_block": "Until the next schedule block",
+        "presence": "Until presence changes"
+      }
+    },
+    "water_heater_operation_mode": {
+      "options": {
+        "off": "Off",
+        "heat": "On",
+        "auto": "Follow schedule"
       }
     }
   }

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -1,0 +1,201 @@
+"""Validate translation coverage against the Home Assistant action schema."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICES_FILE = ROOT / "custom_components" / "tado_hijack" / "services.yaml"
+TRANSLATIONS_DIR = ROOT / "custom_components" / "tado_hijack" / "translations"
+LANGUAGES = ("en", "de", "cs")
+PLACEHOLDER_PATTERN = re.compile(r"\{[a-zA-Z_][a-zA-Z0-9_]*\}")
+SERVICE_FIELDS_INDENT = 2
+FIELD_INDENT = 4
+
+
+def _load_translation(language: str) -> dict[str, Any]:
+    with (TRANSLATIONS_DIR / f"{language}.json").open(encoding="utf-8") as file:
+        data: dict[str, Any] = json.load(file)
+    return data
+
+
+def _leaf_values(value: dict[str, Any], prefix: str = "") -> Iterator[tuple[str, str]]:
+    for key, item in value.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(item, dict):
+            yield from _leaf_values(item, path)
+        elif isinstance(item, str):
+            yield path, item
+
+
+def _parse_service_schema() -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    services: dict[str, set[str]] = {}
+    selectors: dict[str, set[str]] = {}
+    current_service: str | None = None
+    current_selector: str | None = None
+    in_fields = False
+    in_options = False
+
+    for raw_line in SERVICES_FILE.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.strip()
+        indent = len(raw_line) - len(raw_line.lstrip())
+
+        if indent == 0 and re.fullmatch(r"[a-z][a-z0-9_]*:", stripped):
+            current_service = stripped[:-1]
+            services[current_service] = set()
+            current_selector = None
+            in_fields = False
+            in_options = False
+            continue
+
+        if current_service is None:
+            continue
+
+        if indent == SERVICE_FIELDS_INDENT and stripped == "fields:":
+            in_fields = True
+            continue
+
+        if in_fields and indent == FIELD_INDENT:
+            match = re.fullmatch(r"([a-z][a-z0-9_]*):(?:\s+[&*][a-z0-9_]+)?", stripped)
+            if match:
+                services[current_service].add(match.group(1))
+
+        if stripped.startswith("translation_key:"):
+            current_selector = stripped.split(":", maxsplit=1)[1].strip()
+            selectors.setdefault(current_selector, set())
+            in_options = False
+            continue
+
+        if current_selector is not None and stripped == "options:":
+            in_options = True
+            continue
+
+        if in_options and current_selector is not None and stripped.startswith("- "):
+            selectors[current_selector].add(stripped[2:].strip("\"'"))
+        elif in_options and stripped and not stripped.startswith("#"):
+            in_options = False
+
+    return services, selectors
+
+
+def _validate_leaf_parity(
+    translations: dict[str, dict[str, Any]], errors: list[str]
+) -> None:
+    reference = dict(_leaf_values(translations["en"]))
+    reference_keys = set(reference)
+
+    for language in LANGUAGES[1:]:
+        localized = dict(_leaf_values(translations[language]))
+        localized_keys = set(localized)
+        for key in sorted(reference_keys - localized_keys):
+            errors.append(f"{language}: missing translation key {key}")
+        for key in sorted(localized_keys - reference_keys):
+            errors.append(f"{language}: unexpected translation key {key}")
+        for key in sorted(reference_keys & localized_keys):
+            expected = set(PLACEHOLDER_PATTERN.findall(reference[key]))
+            actual = set(PLACEHOLDER_PATTERN.findall(localized[key]))
+            if actual != expected:
+                errors.append(
+                    f"{language}: placeholder mismatch for {key}: "
+                    f"expected {sorted(expected)}, got {sorted(actual)}"
+                )
+
+
+def _validate_services(
+    translations: dict[str, dict[str, Any]],
+    schema: dict[str, set[str]],
+    errors: list[str],
+) -> None:
+    expected_services = set(schema)
+    for language in LANGUAGES:
+        localized_services = translations[language].get("services", {})
+        actual_services = set(localized_services)
+        for service in sorted(expected_services - actual_services):
+            errors.append(f"{language}: missing action translation services.{service}")
+        for service in sorted(actual_services - expected_services):
+            errors.append(f"{language}: obsolete action translation services.{service}")
+
+        for service in sorted(expected_services & actual_services):
+            localized = localized_services[service]
+            for metadata_key in ("name", "description"):
+                if not localized.get(metadata_key):
+                    errors.append(
+                        f"{language}: missing services.{service}.{metadata_key}"
+                    )
+
+            localized_fields = localized.get("fields", {})
+            expected_fields = schema[service]
+            actual_fields = set(localized_fields)
+            for field in sorted(expected_fields - actual_fields):
+                errors.append(f"{language}: missing services.{service}.fields.{field}")
+            for field in sorted(actual_fields - expected_fields):
+                errors.append(f"{language}: obsolete services.{service}.fields.{field}")
+            for field in sorted(expected_fields & actual_fields):
+                for metadata_key in ("name", "description"):
+                    if not localized_fields[field].get(metadata_key):
+                        errors.append(
+                            f"{language}: missing services.{service}.fields."
+                            f"{field}.{metadata_key}"
+                        )
+
+
+def _validate_selectors(
+    translations: dict[str, dict[str, Any]],
+    schema: dict[str, set[str]],
+    errors: list[str],
+) -> None:
+    for language in LANGUAGES:
+        localized_selectors = translations[language].get("selector", {})
+        for selector, expected_options in schema.items():
+            options = localized_selectors.get(selector, {}).get("options")
+            if not isinstance(options, dict):
+                errors.append(f"{language}: missing selector.{selector}.options")
+                continue
+
+            actual_options = set(options)
+            for option in sorted(expected_options - actual_options):
+                errors.append(
+                    f"{language}: missing selector.{selector}.options.{option}"
+                )
+            for option in sorted(actual_options - expected_options):
+                errors.append(
+                    f"{language}: unexpected selector.{selector}.options.{option}"
+                )
+            for option in sorted(expected_options & actual_options):
+                if not options[option]:
+                    errors.append(
+                        f"{language}: empty selector.{selector}.options.{option}"
+                    )
+
+
+def main() -> int:
+    """Run all translation checks and return a process exit code."""
+    translations = {language: _load_translation(language) for language in LANGUAGES}
+    services, selectors = _parse_service_schema()
+    errors: list[str] = []
+
+    _validate_leaf_parity(translations, errors)
+    _validate_services(translations, services, errors)
+    _validate_selectors(translations, selectors, errors)
+
+    if errors:
+        print("Translation validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print(
+        "Translation validation passed for "
+        f"{len(LANGUAGES)} languages, {len(services)} actions, and "
+        f"{len(selectors)} translated selectors."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -167,7 +167,7 @@ def _validate_selectors(
                     f"{language}: unexpected selector.{selector}.options.{option}"
                 )
             for option in sorted(expected_options & actual_options):
-                if not options[option]:
+                if not options[option].strip():
                     errors.append(
                         f"{language}: empty selector.{selector}.options.{option}"
                     )


### PR DESCRIPTION
## What does this PR do?

- Syncs action translations with the current services.yaml schema, replacing stale set_timer* entries with set_mode* and set_water_heater_mode.
- Adds missing config_entry field metadata and translated selector options for refresh type, HVAC mode, overlay mode, and hot-water mode.
- Moves action names and descriptions to the translation files, following Home Assistant localization conventions.
- Polishes Czech terminology, capitalization, units, and user-facing API quota/proxy wording.
- Adds a dependency-free translation validator and runs it in PR CI to prevent future schema drift.

## Related Issue

Fixes #120

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

## Affected Generation(s)

- [ ] V2 - GW Bridge
- [ ] V3 Classic (HomeKit)
- [ ] Tado X (Matter)
- [x] All / not generation-specific

## Testing

- python scripts/validate_translations.py — 3 languages, 8 actions, and 4 translated selectors passed.
- Ruff lint and format checks passed for the new validator.
- MyPy passed for the new validator.
- yamllint passed for services.yaml and the updated PR workflow.
- All three translation JSON files parsed successfully.
- Real hardware testing is not applicable: this changes UI metadata/translations and CI only; runtime action handlers are unchanged.

## Checklist

- [ ] Full pre-commit suite passes (targeted Ruff, MyPy, yamllint, JSON, and translation checks were run locally; hassfest/HACS will run in CI)
- [x] No debug logging left in
- [x] Tested on real hardware or described why not applicable